### PR TITLE
f: changed the action entity id and added tests

### DIFF
--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -30,6 +30,6 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@aragon/osx-commons-subgraph": "^0.0.4"
+    "@aragon/osx-commons-subgraph": "^0.0.5"
   }
 }

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -11,7 +11,7 @@ interface IProposal {
   daoAddress: Bytes!
   creator: Bytes!
   metadata: String
-  actions: [ProposalAction!]! @derivedFrom(field: "proposal")
+  actions: [Action!]! @derivedFrom(field: "proposal")
   allowFailureMap: BigInt!
   executed: Boolean!
   createdAt: BigInt!
@@ -103,7 +103,7 @@ type TokenVotingVote @entity {
 type TokenVotingProposal implements IProposal @entity {
   id: ID! # pluginAddress + proposalId (padded)
   daoAddress: Bytes!
-  actions: [ProposalAction!]! @derivedFrom(field: "proposal")
+  actions: [Action!]! @derivedFrom(field: "proposal")
   allowFailureMap: BigInt!
   plugin: TokenVotingPlugin!
   pluginProposalId: BigInt! # pluginAddress + proposalId padded
@@ -138,7 +138,7 @@ type TokenVotingProposal implements IProposal @entity {
 
 # Executions
 
-type ProposalAction implements IAction @entity(immutable: true) {
+type Action implements IAction @entity(immutable: true) {
   id: ID! # proposalId + action index
   to: Bytes!
   value: BigInt!

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -11,9 +11,8 @@ interface IProposal {
   daoAddress: Bytes!
   creator: Bytes!
   metadata: String
-  actions: [Action!]! @derivedFrom(field: "proposal")
+  actions: [ProposalAction!]! @derivedFrom(field: "proposal")
   allowFailureMap: BigInt!
-  failureMap: BigInt
   executed: Boolean!
   createdAt: BigInt!
   startDate: BigInt!
@@ -25,6 +24,14 @@ interface Token {
   id: ID! # use address as id
   name: String
   symbol: String
+}
+
+interface IAction {
+  id: ID! # ActionEntityId
+  to: Bytes!
+  value: BigInt!
+  data: Bytes!
+  daoAddress: Bytes!
 }
 
 # Enums
@@ -96,9 +103,8 @@ type TokenVotingVote @entity {
 type TokenVotingProposal implements IProposal @entity {
   id: ID! # pluginAddress + proposalId (padded)
   daoAddress: Bytes!
-  actions: [Action!]! @derivedFrom(field: "proposal")
+  actions: [ProposalAction!]! @derivedFrom(field: "proposal")
   allowFailureMap: BigInt!
-  failureMap: BigInt
   plugin: TokenVotingPlugin!
   pluginProposalId: BigInt! # pluginAddress + proposalId padded
   creator: Bytes!
@@ -132,14 +138,15 @@ type TokenVotingProposal implements IProposal @entity {
 
 # Executions
 
-type Action @entity {
+type ProposalAction implements IAction @entity(immutable: true) {
   id: ID! # proposalId + action index
   to: Bytes!
   value: BigInt!
   data: Bytes!
   daoAddress: Bytes!
+
+  # proposal specific data
   proposal: IProposal!
-  execResult: Bytes
 }
 
 # Token Contracts

--- a/packages/subgraph/src/plugin/plugin.ts
+++ b/packages/subgraph/src/plugin/plugin.ts
@@ -31,7 +31,6 @@ import {
   Bytes,
   dataSource,
   DataSourceContext,
-  log,
 } from '@graphprotocol/graph-ts';
 
 export function handleProposalCreated(event: ProposalCreated): void {

--- a/packages/subgraph/src/plugin/plugin.ts
+++ b/packages/subgraph/src/plugin/plugin.ts
@@ -1,5 +1,5 @@
 import {
-  ProposalAction,
+  Action,
   TokenVotingPlugin,
   TokenVotingProposal,
   TokenVotingVoter,
@@ -103,7 +103,7 @@ export function _handleProposalCreated(
         index
       );
 
-      const actionEntity = new ProposalAction(actionId);
+      const actionEntity = new Action(actionId);
       actionEntity.to = action.to;
       actionEntity.value = action.value;
       actionEntity.data = action.data;

--- a/packages/subgraph/src/plugin/plugin.ts
+++ b/packages/subgraph/src/plugin/plugin.ts
@@ -1,5 +1,5 @@
 import {
-  Action,
+  ProposalAction,
   TokenVotingPlugin,
   TokenVotingProposal,
   TokenVotingVoter,
@@ -16,17 +16,22 @@ import {
 } from '../../generated/templates/TokenVoting/TokenVoting';
 import {RATIO_BASE, VOTER_OPTIONS, VOTING_MODES} from '../utils/constants';
 import {identifyAndFetchOrCreateERC20TokenEntity} from '../utils/erc20';
-import {generateMemberEntityId, generateVoteEntityId} from '../utils/ids';
 import {
   generateActionEntityId,
+  generateMemberEntityId,
+  generateVoteEntityId,
+} from '../utils/ids';
+import {
   generatePluginEntityId,
   generateProposalEntityId,
 } from '@aragon/osx-commons-subgraph';
 import {
+  Address,
   BigInt,
   Bytes,
   dataSource,
   DataSourceContext,
+  log,
 } from '@graphprotocol/graph-ts';
 
 export function handleProposalCreated(event: ProposalCreated): void {
@@ -92,14 +97,20 @@ export function _handleProposalCreated(
     for (let index = 0; index < actions.length; index++) {
       const action = actions[index];
 
-      const actionId = generateActionEntityId(proposalEntityId, index);
+      const actionId = generateActionEntityId(
+        pluginAddress,
+        Address.fromString(daoId),
+        pluginProposalId.toString(),
+        index
+      );
 
-      const actionEntity = new Action(actionId);
+      const actionEntity = new ProposalAction(actionId);
       actionEntity.to = action.to;
       actionEntity.value = action.value;
       actionEntity.data = action.data;
       actionEntity.daoAddress = Bytes.fromHexString(daoId);
       actionEntity.proposal = proposalEntityId;
+      actionEntity.executed = false;
       actionEntity.save();
     }
     proposalEntity.isSignaling = actions.length == 0;

--- a/packages/subgraph/src/plugin/plugin.ts
+++ b/packages/subgraph/src/plugin/plugin.ts
@@ -109,7 +109,6 @@ export function _handleProposalCreated(
       actionEntity.data = action.data;
       actionEntity.daoAddress = Bytes.fromHexString(daoId);
       actionEntity.proposal = proposalEntityId;
-      actionEntity.executed = false;
       actionEntity.save();
     }
     proposalEntity.isSignaling = actions.length == 0;

--- a/packages/subgraph/src/plugin/plugin.ts
+++ b/packages/subgraph/src/plugin/plugin.ts
@@ -16,14 +16,11 @@ import {
 } from '../../generated/templates/TokenVoting/TokenVoting';
 import {RATIO_BASE, VOTER_OPTIONS, VOTING_MODES} from '../utils/constants';
 import {identifyAndFetchOrCreateERC20TokenEntity} from '../utils/erc20';
-import {
-  generateActionEntityId,
-  generateMemberEntityId,
-  generateVoteEntityId,
-} from '../utils/ids';
+import {generateMemberEntityId, generateVoteEntityId} from '../utils/ids';
 import {
   generatePluginEntityId,
   generateProposalEntityId,
+  generateActionEntityId,
 } from '@aragon/osx-commons-subgraph';
 import {
   Address,

--- a/packages/subgraph/src/utils/ids.ts
+++ b/packages/subgraph/src/utils/ids.ts
@@ -1,6 +1,7 @@
 import {bigIntToBytes32} from './bytes';
 import {
   generateEntityIdFromAddress,
+  generateActionEntityId as _generateActionEntityId,
   generateEntityIdFromBytes,
 } from '@aragon/osx-commons-subgraph';
 import {Address, BigInt, Bytes} from '@graphprotocol/graph-ts';
@@ -55,32 +56,4 @@ export function getProposalId(
     .toHexString()
     .concat('_')
     .concat(bigIntToBytes32(pluginProposalId));
-}
-
-/**
- * @dev TODO: move this to OSx commons subgraph
- *
- * @param caller the user/plugin that will invoke the execute function on the DAO
- * @param daoAddress the DAO address
- * @param callId the callID determined by the user or plugin
- * @param index the index # of the action in the batch
- *
- * @returns a deterministic Action ID for an action on the DAO.
- * This implementation only relies on data that can be fetched
- * from the event logs of the `Executed` event, so can be used
- * by client applications to query both the OSx core and the plugin
- * subgraphs.
- */
-export function generateActionEntityId(
-  caller: Address,
-  daoAddress: Address,
-  callId: string,
-  index: i32
-): string {
-  return [
-    generateEntityIdFromAddress(caller),
-    generateEntityIdFromAddress(daoAddress),
-    callId,
-    index.toString(),
-  ].join('_');
 }

--- a/packages/subgraph/src/utils/ids.ts
+++ b/packages/subgraph/src/utils/ids.ts
@@ -1,7 +1,6 @@
 import {bigIntToBytes32} from './bytes';
 import {
   generateEntityIdFromAddress,
-  generateActionEntityId as _generateActionEntityId,
   generateEntityIdFromBytes,
 } from '@aragon/osx-commons-subgraph';
 import {Address, BigInt, Bytes} from '@graphprotocol/graph-ts';

--- a/packages/subgraph/src/utils/ids.ts
+++ b/packages/subgraph/src/utils/ids.ts
@@ -56,3 +56,31 @@ export function getProposalId(
     .concat('_')
     .concat(bigIntToBytes32(pluginProposalId));
 }
+
+/**
+ * @dev TODO: move this to OSx commons subgraph
+ *
+ * @param caller the user/plugin that will invoke the execute function on the DAO
+ * @param daoAddress the DAO address
+ * @param callId the callID determined by the user or plugin
+ * @param index the index # of the action in the batch
+ *
+ * @returns a deterministic Action ID for an action on the DAO.
+ * This implementation only relies on data that can be fetched
+ * from the event logs of the `Executed` event, so can be used
+ * by client applications to query both the OSx core and the plugin
+ * subgraphs.
+ */
+export function generateActionEntityId(
+  caller: Address,
+  daoAddress: Address,
+  callId: string,
+  index: i32
+): string {
+  return [
+    generateEntityIdFromAddress(caller),
+    generateEntityIdFromAddress(daoAddress),
+    callId,
+    index.toString(),
+  ].join('_');
+}

--- a/packages/subgraph/tests/plugin/plugin.test.ts
+++ b/packages/subgraph/tests/plugin/plugin.test.ts
@@ -9,7 +9,6 @@ import {
 } from '../../src/plugin/plugin';
 import {VOTING_MODES} from '../../src/utils/constants';
 import {GOVERNANCE_WRAPPED_ERC20_INTERFACE_ID} from '../../src/utils/constants';
-import {generateActionEntityId} from '../../src/utils/ids';
 import {
   ExtendedERC20Contract,
   ExtendedERC20WrapperContract,
@@ -28,7 +27,10 @@ import {
   ERC20_AMOUNT_FULL,
   DAO_ADDRESS,
 } from '../utils/constants';
-import {createDummyAction} from '@aragon/osx-commons-subgraph';
+import {
+  createDummyAction,
+  generateActionEntityId,
+} from '@aragon/osx-commons-subgraph';
 import {Address, bigInt, BigInt, ethereum} from '@graphprotocol/graph-ts';
 import {
   assert,
@@ -400,26 +402,5 @@ describe('Testing Actions', () => {
     assert.fieldEquals('Action', actionID, 'value', dummyActionValue);
     assert.fieldEquals('Action', actionID, 'data', dummyActionData);
     assert.fieldEquals('Action', actionID, 'proposal', proposal.id);
-  });
-
-  test('We correctly generate the action ID from the arguments', () => {
-    let caller = PLUGIN_REPO_ADDRESS;
-    let daoAddress = DAO_ADDRESS;
-    let callId = 'c4ll me';
-    let index = 255;
-
-    let actionId = generateActionEntityId(
-      Address.fromString(caller),
-      Address.fromString(daoAddress),
-      callId,
-      index
-    );
-
-    assert.stringEquals(
-      actionId,
-      [checksum(caller), checksum(daoAddress), callId, index.toString()].join(
-        '_'
-      )
-    );
   });
 });

--- a/packages/subgraph/tests/plugin/plugin.test.ts
+++ b/packages/subgraph/tests/plugin/plugin.test.ts
@@ -405,7 +405,6 @@ describe('Testing Actions', () => {
     assert.fieldEquals('ProposalAction', actionID, 'value', dummyActionValue);
     assert.fieldEquals('ProposalAction', actionID, 'data', dummyActionData);
     assert.fieldEquals('ProposalAction', actionID, 'proposal', proposal.id);
-    assert.fieldEquals('ProposalAction', actionID, 'executed', 'false');
   });
 
   test('We correctly generate the action ID', () => {

--- a/packages/subgraph/tests/plugin/plugin.test.ts
+++ b/packages/subgraph/tests/plugin/plugin.test.ts
@@ -312,7 +312,7 @@ function checksum(s: string): string {
 describe('Testing Actions', () => {
   test('A new proposal action is registered during the proposal creation', () => {
     // manual re-write so this approach can be ported to other plugins
-    assert.entityCount('ProposalAction', 0);
+    assert.entityCount('Action', 0);
     assert.entityCount('TokenVotingProposal', 0);
 
     let tokenVotingPlugin = new ExtendedTokenVotingPlugin().withDefaultValues();
@@ -386,7 +386,7 @@ describe('Testing Actions', () => {
     _handleProposalCreated(proposalEvent, DAO_ADDRESS, metadata);
 
     // step 3: check that the proposal action was created
-    assert.entityCount('ProposalAction', 1);
+    assert.entityCount('Action', 1);
     assert.entityCount('TokenVotingProposal', 1);
 
     // step 3.1: check that the action has the correct fields
@@ -396,15 +396,10 @@ describe('Testing Actions', () => {
       proposalId.toString(),
       0
     );
-    assert.fieldEquals(
-      'ProposalAction',
-      actionID,
-      'to',
-      dummyActionTo.toLowerCase()
-    );
-    assert.fieldEquals('ProposalAction', actionID, 'value', dummyActionValue);
-    assert.fieldEquals('ProposalAction', actionID, 'data', dummyActionData);
-    assert.fieldEquals('ProposalAction', actionID, 'proposal', proposal.id);
+    assert.fieldEquals('Action', actionID, 'to', dummyActionTo.toLowerCase());
+    assert.fieldEquals('Action', actionID, 'value', dummyActionValue);
+    assert.fieldEquals('Action', actionID, 'data', dummyActionData);
+    assert.fieldEquals('Action', actionID, 'proposal', proposal.id);
   });
 
   test('We correctly generate the action ID', () => {

--- a/packages/subgraph/tests/plugin/plugin.test.ts
+++ b/packages/subgraph/tests/plugin/plugin.test.ts
@@ -307,10 +307,6 @@ describe('handleMembershipContractAnnounced', () => {
   });
 });
 
-function checksum(s: string): string {
-  return Address.fromHexString(s).toHexString();
-}
-
 describe('Testing Actions', () => {
   test('A new proposal action is registered during the proposal creation', () => {
     // manual re-write so this approach can be ported to other plugins

--- a/packages/subgraph/tests/plugin/plugin.test.ts
+++ b/packages/subgraph/tests/plugin/plugin.test.ts
@@ -402,7 +402,7 @@ describe('Testing Actions', () => {
     assert.fieldEquals('Action', actionID, 'proposal', proposal.id);
   });
 
-  test('We correctly generate the action ID', () => {
+  test('We correctly generate the action ID from the arguments', () => {
     let caller = PLUGIN_REPO_ADDRESS;
     let daoAddress = DAO_ADDRESS;
     let callId = 'c4ll me';

--- a/packages/subgraph/tests/plugin/plugin.test.ts
+++ b/packages/subgraph/tests/plugin/plugin.test.ts
@@ -1,3 +1,5 @@
+import {ProposalCreated} from '../../generated/templates/TokenVoting/TokenVoting';
+import {PLUGIN_REPO_ADDRESS} from '../../imported/repo-address';
 import {
   handleVoteCast,
   handleProposalExecuted,
@@ -7,6 +9,7 @@ import {
 } from '../../src/plugin/plugin';
 import {VOTING_MODES} from '../../src/utils/constants';
 import {GOVERNANCE_WRAPPED_ERC20_INTERFACE_ID} from '../../src/utils/constants';
+import {generateActionEntityId} from '../../src/utils/ids';
 import {
   ExtendedERC20Contract,
   ExtendedERC20WrapperContract,
@@ -23,12 +26,25 @@ import {
   ZERO,
   TWO,
   ERC20_AMOUNT_FULL,
+  DAO_ADDRESS,
 } from '../utils/constants';
 import {createDummyAction} from '@aragon/osx-commons-subgraph';
-import {bigInt, BigInt} from '@graphprotocol/graph-ts';
-import {assert, clearStore, describe, test} from 'matchstick-as/assembly/index';
+import {Address, bigInt, BigInt, ethereum} from '@graphprotocol/graph-ts';
+import {
+  assert,
+  clearStore,
+  describe,
+  newMockEvent,
+  test,
+} from 'matchstick-as/assembly/index';
 
-let actions = [createDummyAction(DAO_TOKEN_ADDRESS, '0', '0x00000000')];
+let dummyActionTo = DAO_TOKEN_ADDRESS;
+let dummyActionValue = '0';
+let dummyActionData = '0x00000000';
+
+let actions = [
+  createDummyAction(dummyActionTo, dummyActionValue, dummyActionData),
+];
 
 test('Run TokenVoting (handleProposalCreated) mappings with mock event', () => {
   // create state
@@ -286,5 +302,130 @@ describe('handleMembershipContractAnnounced', () => {
     erc20WrappedContract.assertEntity();
 
     clearStore();
+  });
+});
+
+function checksum(s: string): string {
+  return Address.fromHexString(s).toHexString();
+}
+
+describe('Testing Actions', () => {
+  test('A new proposal action is registered during the proposal creation', () => {
+    // manual re-write so this approach can be ported to other plugins
+    assert.entityCount('ProposalAction', 0);
+    assert.entityCount('TokenVotingProposal', 0);
+
+    let tokenVotingPlugin = new ExtendedTokenVotingPlugin().withDefaultValues();
+    let proposal = new ExtendedTokenVotingProposal().withDefaultValues();
+
+    // step 1: create the mock proposal event
+    tokenVotingPlugin.proposalCount = BigInt.fromString(ONE);
+    tokenVotingPlugin.mockCall_getProposalCountCall();
+    proposal.mockCall_getProposal(actions);
+    proposal.mockCall_totalVotingPower();
+
+    const proposalEvent = changetype<ProposalCreated>(newMockEvent());
+    proposalEvent.address = Address.fromString(proposal.plugin);
+
+    let proposalId = new BigInt(0);
+    let creator = proposal.creator;
+    let startDate = proposal.startDate;
+    let endDate = proposal.endDate;
+
+    let metadata: string;
+    if (proposal.metadata) {
+      metadata = proposal.metadata as string;
+    } else {
+      metadata = 'metadata';
+    }
+    let allowFailureMap = proposal.allowFailureMap;
+
+    let proposalIdEvent = new ethereum.EventParam(
+      'proposalId',
+      ethereum.Value.fromUnsignedBigInt(
+        BigInt.fromString(proposalId.toString())
+      )
+    );
+
+    let creatorEvent = new ethereum.EventParam(
+      'creator',
+      ethereum.Value.fromAddress(Address.fromBytes(creator))
+    );
+    let startDateEvent = new ethereum.EventParam(
+      'startDate',
+      ethereum.Value.fromUnsignedBigInt(startDate)
+    );
+    let endDateEvent = new ethereum.EventParam(
+      'endDate',
+      ethereum.Value.fromUnsignedBigInt(endDate)
+    );
+    let metadataEvent = new ethereum.EventParam(
+      'metadata',
+      ethereum.Value.fromString(metadata as string)
+    );
+    let actionsEvent = new ethereum.EventParam(
+      'actions',
+      ethereum.Value.fromTupleArray(actions)
+    );
+    let allowFailureMapEvent = new ethereum.EventParam(
+      'allowFailureMap',
+      ethereum.Value.fromUnsignedBigInt(allowFailureMap)
+    );
+
+    proposalEvent.parameters = [
+      proposalIdEvent,
+      creatorEvent,
+      startDateEvent,
+      endDateEvent,
+      metadataEvent,
+      actionsEvent,
+      allowFailureMapEvent,
+    ];
+
+    // step 2: handle the proposal event
+    _handleProposalCreated(proposalEvent, DAO_ADDRESS, metadata);
+
+    // step 3: check that the proposal action was created
+    assert.entityCount('ProposalAction', 1);
+    assert.entityCount('TokenVotingProposal', 1);
+
+    // step 3.1: check that the action has the correct fields
+    const actionID = generateActionEntityId(
+      Address.fromString(proposal.plugin),
+      Address.fromString(DAO_ADDRESS),
+      proposalId.toString(),
+      0
+    );
+    assert.fieldEquals(
+      'ProposalAction',
+      actionID,
+      'to',
+      dummyActionTo.toLowerCase()
+    );
+    assert.fieldEquals('ProposalAction', actionID, 'value', dummyActionValue);
+    assert.fieldEquals('ProposalAction', actionID, 'data', dummyActionData);
+    assert.fieldEquals('ProposalAction', actionID, 'proposal', proposal.id);
+    assert.fieldEquals('ProposalAction', actionID, 'executed', 'false');
+  });
+
+  test('We correctly generate the action ID', () => {
+    let caller = PLUGIN_REPO_ADDRESS;
+    let daoAddress = DAO_ADDRESS;
+    let callId = 'c4ll me';
+    let index = 255;
+
+    let actionId = generateActionEntityId(
+      Address.fromString(caller),
+      Address.fromString(daoAddress),
+      callId,
+      index
+    );
+
+    assert.stringEquals(
+      actionId,
+      [checksum(caller), checksum(daoAddress), callId, index.toString()].join(
+        '_'
+      )
+    );
   });
 });

--- a/packages/subgraph/yarn.lock
+++ b/packages/subgraph/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     tslib "^2.6.2"
 
-"@aragon/osx-commons-subgraph@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@aragon/osx-commons-subgraph/-/osx-commons-subgraph-0.0.4.tgz#2aa52f3089d21189c9152d2f3d14c0d7c66d129f"
-  integrity sha512-cqhusJ3HNvMx+t9lXfN+Hy/5ipefNs1Tdxe+y0GvD4qgBMVU4tCbsxOpB9U2JEJNBCzFQj4E/872FFLpIErB4w==
+"@aragon/osx-commons-subgraph@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@aragon/osx-commons-subgraph/-/osx-commons-subgraph-0.0.5.tgz#7e0c0f854e4ca52de1d937595c9bb6ef0370f840"
+  integrity sha512-M5edVTYyHbkcDLr2H8ySCbOpLA+5pUdN7tCYCif0pDP99Wb+/njgO23G2B2FjB4Q3hB0fCkLkQwNp9QplJjqGA==
   dependencies:
     "@graphprotocol/graph-ts" "0.31.0"
 


### PR DESCRIPTION
## Description

Removes execution data from actions inside proposals. Adds manual testing that can be replicated inside other plugins then refactored. 

An ID for generating actions has been created, this will be moved to the osx-commons-subgraph.

A second PR on OSx core is in progress which will make the necessary changes to the subgraphs.

https://www.notion.so/aragonorg/execResult-in-the-Subgraph-8879407b1d6f42f19530ef6bc06b3dc6#da8cb903e33342279d88725f068c9506 

Task ID: [OS-1162](https://aragonassociation.atlassian.net/browse/OS-1162)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have updated the `DEPLOYMENT_CHECKLIST` file in the root folder.
- [ ] I have updated the `UPDATE_CHECKLIST` file in the root folder.
- [ ] I have updated the Subgraph and added a QA URL to the description of this PR.


[OS-1162]: https://aragonassociation.atlassian.net/browse/OS-1162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ