### PR TITLE
fix: stop revoking mint permission to dao when plugin is uninstalled 

### DIFF
--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -18,3 +18,4 @@ and this project adheres to the [Aragon OSx Plugin Versioning Convention](https:
 - Hard-coded the `bytes32 internal constant EXECUTE_PERMISSION_ID` constant in `TokenVotingSetup` until it is available in `PermissionLib`.
 - Changed the `prepareInstallation` function in `TokenVotingSetup` to not unnecessarily grant the `UPGRADE_PLUGIN_PERMISSION_ID` permission to the installing DAO.
 - Changed the `prepareUpdate` function in `TokenVotingSetup` to revoke the previously unnecessarily granted `UPGRADE_PLUGIN_PERMISSION_ID` permission from the installing DAO.
+- Changed the `prepareUninstallation` function in `TokenVotingSetup` to not revoke the `MINT_PERMISSION_ID` to the Dao when the plugin is uninstalled.

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -18,4 +18,4 @@ and this project adheres to the [Aragon OSx Plugin Versioning Convention](https:
 - Hard-coded the `bytes32 internal constant EXECUTE_PERMISSION_ID` constant in `TokenVotingSetup` until it is available in `PermissionLib`.
 - Changed the `prepareInstallation` function in `TokenVotingSetup` to not unnecessarily grant the `UPGRADE_PLUGIN_PERMISSION_ID` permission to the installing DAO.
 - Changed the `prepareUpdate` function in `TokenVotingSetup` to revoke the previously unnecessarily granted `UPGRADE_PLUGIN_PERMISSION_ID` permission from the installing DAO.
-- Changed the `prepareUninstallation` function in `TokenVotingSetup` to not revoke the `MINT_PERMISSION_ID` to the Dao when the plugin is uninstalled.
+- Changed the `prepareUninstallation` function in `TokenVotingSetup` to not revoke the `MINT_PERMISSION_ID` to the DAO when the plugin is uninstalled.

--- a/packages/contracts/src/TokenVotingSetup.sol
+++ b/packages/contracts/src/TokenVotingSetup.sol
@@ -267,19 +267,6 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
             condition: PermissionLib.NO_CONDITION,
             permissionId: EXECUTE_PERMISSION_ID
         });
-
-        // Revocation of permission is necessary only if the deployed token is GovernanceERC20,
-        // as GovernanceWrapped does not possess this permission. Only return the following
-        // if it's type of GovernanceERC20, otherwise revoking this permission wouldn't have any effect.
-        if (isGovernanceERC20) {
-            permissions[2] = PermissionLib.MultiTargetPermission({
-                operation: PermissionLib.Operation.Revoke,
-                where: token,
-                who: _dao,
-                condition: PermissionLib.NO_CONDITION,
-                permissionId: GovernanceERC20(token).MINT_PERMISSION_ID()
-            });
-        }
     }
 
     /// @notice Retrieves the interface identifiers supported by the token contract.

--- a/packages/contracts/src/TokenVotingSetup.sol
+++ b/packages/contracts/src/TokenVotingSetup.sol
@@ -241,15 +241,7 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
             revert WrongHelpersArrayLength({length: helperLength});
         }
 
-        // token can be either GovernanceERC20, GovernanceWrappedERC20, or IVotesUpgradeable, which
-        // does not follow the GovernanceERC20 and GovernanceWrappedERC20 standard.
-        address token = _payload.currentHelpers[0];
-
-        bool[] memory supportedIds = _getTokenInterfaceIds(token);
-
-        bool isGovernanceERC20 = supportedIds[0] && supportedIds[1] && !supportedIds[2];
-
-        permissions = new PermissionLib.MultiTargetPermission[](isGovernanceERC20 ? 3 : 2);
+        permissions = new PermissionLib.MultiTargetPermission[](2);
 
         // Set permissions to be Revoked.
         permissions[0] = PermissionLib.MultiTargetPermission({

--- a/packages/contracts/src/build-metadata.json
+++ b/packages/contracts/src/build-metadata.json
@@ -1,6 +1,6 @@
 {
   "ui": {},
-  "change": "v1.3\n - Removed an unneccessary permission that allowed the Dao to upgrade the plugin, because this is supposed to happens as part of the update itself. The unnecessary permission, which was granted on installation of previous versions, will be automatically removed with the update to this version.\n - Allows the DAO to still mint new tokens after uninstallation by not revoking the associated permission.",
+  "change": "v1.3\n - Removed an unneccessary permission that allowed the Dao to upgrade the plugin, because this is supposed to happens as part of the update itself. The unnecessary permission, which was granted on installation of previous versions, will be automatically removed with the update to this version.\n - Allowed the DAO to still mint new tokens after uninstallation by not revoking the associated permission.",
   "pluginSetup": {
     "prepareInstallation": {
       "description": "The information required for the installation.",

--- a/packages/contracts/src/build-metadata.json
+++ b/packages/contracts/src/build-metadata.json
@@ -1,6 +1,6 @@
 {
   "ui": {},
-  "change": "v1.3\n - Removed an unneccessary permission that allowed the Dao to upgrade the plugin, because this is supposed to happens as part of the update itself. The unnecessary permission, which was granted on installation of previous versions, will be automatically removed with the update to this version.\n",
+  "change": "v1.3\n - Removed an unneccessary permission that allowed the Dao to upgrade the plugin, because this is supposed to happens as part of the update itself. The unnecessary permission, which was granted on installation of previous versions, will be automatically removed with the update to this version.\n - Stopped revoking the permission that allows the Dao to mint new tokens since even when the plugin is installed the token belongs to the Dao.",
   "pluginSetup": {
     "prepareInstallation": {
       "description": "The information required for the installation.",

--- a/packages/contracts/src/build-metadata.json
+++ b/packages/contracts/src/build-metadata.json
@@ -1,6 +1,6 @@
 {
   "ui": {},
-  "change": "v1.3\n - Removed an unneccessary permission that allowed the Dao to upgrade the plugin, because this is supposed to happens as part of the update itself. The unnecessary permission, which was granted on installation of previous versions, will be automatically removed with the update to this version.\n - Stopped revoking the permission that allows the Dao to mint new tokens since even when the plugin is installed the token belongs to the Dao.",
+  "change": "v1.3\n - Removed an unneccessary permission that allowed the Dao to upgrade the plugin, because this is supposed to happens as part of the update itself. The unnecessary permission, which was granted on installation of previous versions, will be automatically removed with the update to this version.\n - Allow the DAO to still mint new tokens ater uninstallation by not revoking the associated permission.",
   "pluginSetup": {
     "prepareInstallation": {
       "description": "The information required for the installation.",

--- a/packages/contracts/src/build-metadata.json
+++ b/packages/contracts/src/build-metadata.json
@@ -1,6 +1,6 @@
 {
   "ui": {},
-  "change": "v1.3\n - Removed an unneccessary permission that allowed the Dao to upgrade the plugin, because this is supposed to happens as part of the update itself. The unnecessary permission, which was granted on installation of previous versions, will be automatically removed with the update to this version.\n - Allow the DAO to still mint new tokens ater uninstallation by not revoking the associated permission.",
+  "change": "v1.3\n - Removed an unneccessary permission that allowed the Dao to upgrade the plugin, because this is supposed to happens as part of the update itself. The unnecessary permission, which was granted on installation of previous versions, will be automatically removed with the update to this version.\n - Allows the DAO to still mint new tokens after uninstallation by not revoking the associated permission.",
   "pluginSetup": {
     "prepareInstallation": {
       "description": "The information required for the installation.",

--- a/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
+++ b/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
@@ -727,6 +727,18 @@ describe('TokenVotingSetup', function () {
 
       expect(permissions1.length).to.be.equal(2);
       expect(permissions1).to.deep.equal(essentialPermissions);
+
+      const permissions2 = await pluginSetup.callStatic.prepareUninstallation(
+        dao.address,
+        {
+          plugin,
+          currentHelpers: [governanceERC20.address],
+          data: prepareUninstallationInputs,
+        }
+      );
+
+      expect(permissions2.length).to.be.equal(2);
+      expect(permissions2).to.deep.equal(essentialPermissions);
     });
   });
 });

--- a/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
+++ b/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
@@ -727,27 +727,6 @@ describe('TokenVotingSetup', function () {
 
       expect(permissions1.length).to.be.equal(2);
       expect(permissions1).to.deep.equal(essentialPermissions);
-
-      const permissions2 = await pluginSetup.callStatic.prepareUninstallation(
-        dao.address,
-        {
-          plugin,
-          currentHelpers: [governanceERC20.address],
-          data: prepareUninstallationInputs,
-        }
-      );
-
-      expect(permissions2.length).to.be.equal(3);
-      expect(permissions2).to.deep.equal([
-        ...essentialPermissions,
-        [
-          Operation.Revoke,
-          governanceERC20.address,
-          dao.address,
-          AddressZero,
-          MINT_PERMISSION_ID,
-        ],
-      ]);
     });
   });
 });


### PR DESCRIPTION
PR for stop revoking `MINT_PERMISSION_ID` to the dao. 

#### changes summary 
- in `TokenVotingSetup` stop revoking the permission during the uninstallation.
- in tests

**Any suggestion in the changelog description or in the metadata is more than welcome** 

Task ID: [OS-1361](https://aragonassociation.atlassian.net/browse/OS-1361)


[OS-1361]: https://aragonassociation.atlassian.net/browse/OS-1361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ