### PR TITLE
feat: Add minimal approval configuration

### DIFF
--- a/packages/contracts/src/IMajorityVoting.sol
+++ b/packages/contracts/src/IMajorityVoting.sol
@@ -38,7 +38,7 @@ interface IMajorityVoting {
 
     /// @notice Returns the min approval value stored configured.
     /// @return The minimal approval value.
-    function minApproval() external view returns (uint32);
+    function minApproval() external view returns (uint256);
 
     /// @notice Returns the minimum participation parameter stored in the voting settings.
     /// @return The minimum participation parameter.

--- a/packages/contracts/src/IMajorityVoting.sol
+++ b/packages/contracts/src/IMajorityVoting.sol
@@ -36,6 +36,9 @@ interface IMajorityVoting {
     /// @return The support threshold parameter.
     function supportThreshold() external view returns (uint32);
 
+    // todo natspec
+    function minApproval() external view returns (uint32);
+
     /// @notice Returns the minimum participation parameter stored in the voting settings.
     /// @return The minimum participation parameter.
     function minParticipation() external view returns (uint32);
@@ -60,6 +63,9 @@ interface IMajorityVoting {
     /// @param _proposalId The ID of the proposal.
     /// @return Returns `true` if the participation is greater than the minimum participation and `false` otherwise.
     function isMinParticipationReached(uint256 _proposalId) external view returns (bool);
+
+    // todo natspec
+    function isMinApprovalReached(uint256 _proposalId) external view returns (bool);
 
     /// @notice Checks if an account can participate on a proposal vote. This can be because the vote
     /// - has not started,

--- a/packages/contracts/src/IMajorityVoting.sol
+++ b/packages/contracts/src/IMajorityVoting.sol
@@ -36,7 +36,8 @@ interface IMajorityVoting {
     /// @return The support threshold parameter.
     function supportThreshold() external view returns (uint32);
 
-    // todo natspec
+    /// @notice Returns the min approval value stored configured.
+    /// @return The minimal approval value.
     function minApproval() external view returns (uint32);
 
     /// @notice Returns the minimum participation parameter stored in the voting settings.
@@ -64,7 +65,11 @@ interface IMajorityVoting {
     /// @return Returns `true` if the participation is greater than the minimum participation and `false` otherwise.
     function isMinParticipationReached(uint256 _proposalId) external view returns (bool);
 
-    // todo natspec
+    /// @notice Checks if the min approval value defined as:
+    ///$$\texttt{minApproval} = \frac{N_\text{yes}}{N_\text{total}}$$
+    /// for a proposal vote is greater or equal than the minimum approval value.
+    /// @param _proposalId The ID of the proposal.
+    /// @return Returns `true` if the participation is greater than the minimum participation and `false` otherwise.
     function isMinApprovalReached(uint256 _proposalId) external view returns (bool);
 
     /// @notice Checks if an account can participate on a proposal vote. This can be because the vote

--- a/packages/contracts/src/MajorityVotingBase.sol
+++ b/packages/contracts/src/MajorityVotingBase.sol
@@ -491,7 +491,7 @@ abstract contract MajorityVotingBase is
         _updateVotingSettings(_votingSettings);
     }
 
-    // todo define if permission should be the same one as update settings
+    // todo TBD define if permission should be the same one as update settings
     /// @notice Updates the minimal approval value.
     /// @param _minApproval The new minimal approval value.
     function updateMinApproval(

--- a/packages/contracts/src/MajorityVotingBase.sol
+++ b/packages/contracts/src/MajorityVotingBase.sol
@@ -590,7 +590,6 @@ abstract contract MajorityVotingBase is
         if (!isMinParticipationReached(_proposalId)) {
             return false;
         }
-        // ! if the minApproval is zero should ignore it?
         if (!isMinApprovalReached(_proposalId)) {
             return false;
         }

--- a/packages/contracts/src/MajorityVotingBase.sol
+++ b/packages/contracts/src/MajorityVotingBase.sol
@@ -304,9 +304,9 @@ abstract contract MajorityVotingBase is
         override(ERC165Upgradeable, PluginUUPSUpgradeable, ProposalUpgradeable)
         returns (bool)
     {
-        // In addition to the current IMajorityVoting interface, also support previous version of the interface that did not
-        // include the isMinApprovalReached() and minApproval() functions, same happens with MAJORITY_VOTING_BASE_INTERFACE_ID which
-        // did not included updateMinApproval() function.
+        // In addition to the current IMajorityVoting interface, also support previous version
+        // that did not include the isMinApprovalReached() and minApproval() functions, same
+        // happens with MAJORITY_VOTING_BASE_INTERFACE which did not included updateMinApproval().
         return
             _interfaceId == MAJORITY_VOTING_BASE_INTERFACE_ID ||
             _interfaceId == MAJORITY_VOTING_BASE_INTERFACE_ID ^ this.updateMinApproval.selector ||

--- a/packages/contracts/src/MajorityVotingBase.sol
+++ b/packages/contracts/src/MajorityVotingBase.sol
@@ -279,10 +279,14 @@ abstract contract MajorityVotingBase is
     // solhint-disable-next-line func-name-mixedcase
     function __MajorityVotingBase_init(
         IDAO _dao,
-        VotingSettings calldata _votingSettings
+        VotingSettings calldata _votingSettings,
+        uint32 _minApproval
     ) internal onlyInitializing {
         __PluginUUPSUpgradeable_init(_dao);
         _updateVotingSettings(_votingSettings);
+        if (_minApproval != 0) {
+            _updateMinApproval(_minApproval);
+        }
     }
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
@@ -487,7 +491,7 @@ abstract contract MajorityVotingBase is
     function updateMinApproval(
         uint32 _minApproval
     ) external virtual auth(UPDATE_VOTING_SETTINGS_PERMISSION_ID) {
-        minApprovalValue = _minApproval;
+        _updateMinApproval(_minApproval);
     }
 
     /// @notice Creates a new majority voting proposal.
@@ -635,6 +639,11 @@ abstract contract MajorityVotingBase is
             minDuration: _votingSettings.minDuration,
             minProposerVotingPower: _votingSettings.minProposerVotingPower
         });
+    }
+
+    // todo natspec
+    function _updateMinApproval(uint32 _minApproval) internal virtual {
+        minApprovalValue = _minApproval;
     }
 
     /// @notice Validates and returns the proposal vote dates.

--- a/packages/contracts/src/MajorityVotingBase.sol
+++ b/packages/contracts/src/MajorityVotingBase.sol
@@ -213,7 +213,7 @@ abstract contract MajorityVotingBase is
             this.totalVotingPower.selector ^
             this.getProposal.selector ^
             this.updateVotingSettings.selector ^
-            this.updateMinApproval.selector ^
+            this.updateMinApprovals.selector ^
             this.createProposal.selector;
 
     /// @notice The ID of the permission required to call the `updateVotingSettings` function.
@@ -289,7 +289,7 @@ abstract contract MajorityVotingBase is
     ) internal onlyInitializing {
         __PluginUUPSUpgradeable_init(_dao);
         _updateVotingSettings(_votingSettings);
-        _updateMinApproval(_minApprovals);
+        _updateMinApprovals(_minApprovals);
     }
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
@@ -306,10 +306,10 @@ abstract contract MajorityVotingBase is
     {
         // In addition to the current IMajorityVoting interface, also support previous version
         // that did not include the isMinApprovalReached() and minApproval() functions, same
-        // happens with MAJORITY_VOTING_BASE_INTERFACE which did not included updateMinApproval().
+        // happens with MAJORITY_VOTING_BASE_INTERFACE which did not included updateMinApprovals().
         return
             _interfaceId == MAJORITY_VOTING_BASE_INTERFACE_ID ||
-            _interfaceId == MAJORITY_VOTING_BASE_INTERFACE_ID ^ this.updateMinApproval.selector ||
+            _interfaceId == MAJORITY_VOTING_BASE_INTERFACE_ID ^ this.updateMinApprovals.selector ||
             _interfaceId == type(IMajorityVoting).interfaceId ||
             _interfaceId ==
             type(IMajorityVoting).interfaceId ^
@@ -494,10 +494,10 @@ abstract contract MajorityVotingBase is
     // todo TBD define if permission should be the same one as update settings
     /// @notice Updates the minimal approval value.
     /// @param _minApprovals The new minimal approval value.
-    function updateMinApproval(
+    function updateMinApprovals(
         uint32 _minApprovals
     ) external virtual auth(UPDATE_VOTING_SETTINGS_PERMISSION_ID) {
-        _updateMinApproval(_minApprovals);
+        _updateMinApprovals(_minApprovals);
     }
 
     /// @notice Creates a new majority voting proposal.
@@ -648,7 +648,7 @@ abstract contract MajorityVotingBase is
 
     /// @notice Internal function to update minimal approval value.
     /// @param _minApprovals The new minimal approval value.
-    function _updateMinApproval(uint32 _minApprovals) internal virtual {
+    function _updateMinApprovals(uint32 _minApprovals) internal virtual {
         // Require the minimum approval value to be in the interval [0, 10^6],
         // because `>=` comparison is used in the participation criterion.
         if (_minApprovals > RATIO_BASE) {

--- a/packages/contracts/src/MajorityVotingBase.sol
+++ b/packages/contracts/src/MajorityVotingBase.sol
@@ -229,7 +229,7 @@ abstract contract MajorityVotingBase is
 
     /// @notice The minimal ratio of yes votes needed for a proposal succeed.
     /// @dev is not on the VotingSettings for compatibility reasons.
-    uint32 private minApprovals; // added in v1.3
+    uint256 private minApprovals; // added in v1.3
 
     /// @notice Thrown if a date is out of bounds.
     /// @param limit The limit value.
@@ -275,7 +275,7 @@ abstract contract MajorityVotingBase is
 
     /// @notice Emitted when the min approval value is updated.
     /// @param minApprovals The minimum amount of yes votes needed for a proposal succeed.
-    event VotingMinApprovalUpdated(uint32 minApprovals);
+    event VotingMinApprovalUpdated(uint256 minApprovals);
 
     /// @notice Initializes the component to be used by inheriting contracts.
     /// @dev This method is required to support [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822).
@@ -285,7 +285,7 @@ abstract contract MajorityVotingBase is
     function __MajorityVotingBase_init(
         IDAO _dao,
         VotingSettings calldata _votingSettings,
-        uint32 _minApprovals
+        uint256 _minApprovals
     ) internal onlyInitializing {
         __PluginUUPSUpgradeable_init(_dao);
         _updateVotingSettings(_votingSettings);
@@ -413,7 +413,7 @@ abstract contract MajorityVotingBase is
     }
 
     /// @inheritdoc IMajorityVoting
-    function minApproval() public view virtual returns (uint32) {
+    function minApproval() public view virtual returns (uint256) {
         return minApprovals;
     }
 
@@ -495,7 +495,7 @@ abstract contract MajorityVotingBase is
     /// @notice Updates the minimal approval value.
     /// @param _minApprovals The new minimal approval value.
     function updateMinApprovals(
-        uint32 _minApprovals
+        uint256 _minApprovals
     ) external virtual auth(UPDATE_VOTING_SETTINGS_PERMISSION_ID) {
         _updateMinApprovals(_minApprovals);
     }
@@ -648,7 +648,7 @@ abstract contract MajorityVotingBase is
 
     /// @notice Internal function to update minimal approval value.
     /// @param _minApprovals The new minimal approval value.
-    function _updateMinApprovals(uint32 _minApprovals) internal virtual {
+    function _updateMinApprovals(uint256 _minApprovals) internal virtual {
         // Require the minimum approval value to be in the interval [0, 10^6],
         // because `>=` comparison is used in the participation criterion.
         if (_minApprovals > RATIO_BASE) {

--- a/packages/contracts/src/MajorityVotingBase.sol
+++ b/packages/contracts/src/MajorityVotingBase.sol
@@ -227,9 +227,9 @@ abstract contract MajorityVotingBase is
     /// @notice The struct storing the voting settings.
     VotingSettings private votingSettings;
 
-    /// @notice The minimal amount of yes votes needed for a proposal succeed.
-    /// @dev this value is not on the VotingSettings for compatibility reasons.
-    uint32 private minApprovalValue; // added in v1.3
+    /// @notice The minimal ratio of yes votes needed for a proposal succeed.
+    /// @dev is not on the VotingSettings for compatibility reasons.
+    uint32 private minApprovals; // added in v1.3
 
     /// @notice Thrown if a date is out of bounds.
     /// @param limit The limit value.
@@ -414,7 +414,7 @@ abstract contract MajorityVotingBase is
     }
 
     function minApproval() public view virtual returns (uint32) {
-        return minApprovalValue;
+        return minApprovals;
     }
 
     /// @inheritdoc IMajorityVoting
@@ -655,7 +655,7 @@ abstract contract MajorityVotingBase is
             revert RatioOutOfBounds({limit: RATIO_BASE, actual: _minApproval});
         }
 
-        minApprovalValue = _minApproval;
+        minApprovals = _minApproval;
         emit VotingMinApprovalUpdated(_minApproval);
     }
 

--- a/packages/contracts/src/MajorityVotingBase.sol
+++ b/packages/contracts/src/MajorityVotingBase.sol
@@ -493,11 +493,11 @@ abstract contract MajorityVotingBase is
 
     // todo TBD define if permission should be the same one as update settings
     /// @notice Updates the minimal approval value.
-    /// @param _minApproval The new minimal approval value.
+    /// @param _minApprovals The new minimal approval value.
     function updateMinApproval(
-        uint32 _minApproval
+        uint32 _minApprovals
     ) external virtual auth(UPDATE_VOTING_SETTINGS_PERMISSION_ID) {
-        _updateMinApproval(_minApproval);
+        _updateMinApproval(_minApprovals);
     }
 
     /// @notice Creates a new majority voting proposal.
@@ -647,16 +647,16 @@ abstract contract MajorityVotingBase is
     }
 
     /// @notice Internal function to update minimal approval value.
-    /// @param _minApproval The new minimal approval value.
-    function _updateMinApproval(uint32 _minApproval) internal virtual {
+    /// @param _minApprovals The new minimal approval value.
+    function _updateMinApproval(uint32 _minApprovals) internal virtual {
         // Require the minimum approval value to be in the interval [0, 10^6],
         // because `>=` comparison is used in the participation criterion.
-        if (_minApproval > RATIO_BASE) {
-            revert RatioOutOfBounds({limit: RATIO_BASE, actual: _minApproval});
+        if (_minApprovals > RATIO_BASE) {
+            revert RatioOutOfBounds({limit: RATIO_BASE, actual: _minApprovals});
         }
 
-        minApprovals = _minApproval;
-        emit VotingMinApprovalUpdated(_minApproval);
+        minApprovals = _minApprovals;
+        emit VotingMinApprovalUpdated(_minApprovals);
     }
 
     /// @notice Validates and returns the proposal vote dates.

--- a/packages/contracts/src/MajorityVotingBase.sol
+++ b/packages/contracts/src/MajorityVotingBase.sol
@@ -406,11 +406,10 @@ abstract contract MajorityVotingBase is
 
     /// @inheritdoc IMajorityVoting
     function isMinApprovalReached(uint256 _proposalId) public view virtual returns (bool) {
-        Proposal storage proposal_ = proposals[_proposalId];
-
-        return proposal_.tally.yes >= proposal_.minApprovalPower;
+        return proposals[_proposalId].tally.yes >= proposals[_proposalId].minApprovalPower;
     }
 
+    /// @inheritdoc IMajorityVoting
     function minApproval() public view virtual returns (uint32) {
         return minApprovals;
     }

--- a/packages/contracts/src/MajorityVotingBase.sol
+++ b/packages/contracts/src/MajorityVotingBase.sol
@@ -274,8 +274,8 @@ abstract contract MajorityVotingBase is
     );
 
     /// @notice Emitted when the min approval value is updated.
-    /// @param minApproval The minimum amount of yes votes needed for a proposal succeed.
-    event VotingMinApprovalUpdated(uint32 minApproval);
+    /// @param minApprovals The minimum amount of yes votes needed for a proposal succeed.
+    event VotingMinApprovalUpdated(uint32 minApprovals);
 
     /// @notice Initializes the component to be used by inheriting contracts.
     /// @dev This method is required to support [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822).
@@ -285,11 +285,11 @@ abstract contract MajorityVotingBase is
     function __MajorityVotingBase_init(
         IDAO _dao,
         VotingSettings calldata _votingSettings,
-        uint32 _minApproval
+        uint32 _minApprovals
     ) internal onlyInitializing {
         __PluginUUPSUpgradeable_init(_dao);
         _updateVotingSettings(_votingSettings);
-        _updateMinApproval(_minApproval);
+        _updateMinApproval(_minApprovals);
     }
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.

--- a/packages/contracts/src/MajorityVotingBase.sol
+++ b/packages/contracts/src/MajorityVotingBase.sol
@@ -227,7 +227,7 @@ abstract contract MajorityVotingBase is
     /// @notice The struct storing the voting settings.
     VotingSettings private votingSettings;
 
-    // todo TBD is this is the best way, can not add it to the voting settings because will break the interface
+    // todo TBD if this is the best way, can not add it to the voting settings because will break the interface
     uint32 private minApprovalValue;
 
     /// @notice Thrown if a date is out of bounds.
@@ -271,6 +271,10 @@ abstract contract MajorityVotingBase is
         uint64 minDuration,
         uint256 minProposerVotingPower
     );
+
+    /// @notice Emitted when the min approval value is updated.
+    /// @param minApproval The minimum amount of yes votes needed for a proposal succeed.
+    event VotingMinApprovalUpdated(uint32 minApproval);
 
     /// @notice Initializes the component to be used by inheriting contracts.
     /// @dev This method is required to support [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822).
@@ -486,8 +490,9 @@ abstract contract MajorityVotingBase is
         _updateVotingSettings(_votingSettings);
     }
 
-    // todo define if permission should be the one as update settings
-    // todo add a new event emission
+    // todo define if permission should be the same one as update settings
+    /// @notice Updates the minimal approval value.
+    /// @param _minApproval The new minimal approval value.
     function updateMinApproval(
         uint32 _minApproval
     ) external virtual auth(UPDATE_VOTING_SETTINGS_PERMISSION_ID) {
@@ -641,9 +646,11 @@ abstract contract MajorityVotingBase is
         });
     }
 
-    // todo natspec
+    /// @notice Internal function to update minimal approval value.
+    /// @param _minApproval The new minimal approval value.
     function _updateMinApproval(uint32 _minApproval) internal virtual {
         minApprovalValue = _minApproval;
+        emit VotingMinApprovalUpdated(_minApproval);
     }
 
     /// @notice Validates and returns the proposal vote dates.
@@ -687,6 +694,5 @@ abstract contract MajorityVotingBase is
     /// new variables without shifting down storage in the inheritance chain
     /// (see [OpenZeppelin's guide about storage gaps]
     /// (https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps)).
-    // todo double check the gap is correct
     uint256[46] private __gap;
 }

--- a/packages/contracts/src/MajorityVotingBase.sol
+++ b/packages/contracts/src/MajorityVotingBase.sol
@@ -289,9 +289,7 @@ abstract contract MajorityVotingBase is
     ) internal onlyInitializing {
         __PluginUUPSUpgradeable_init(_dao);
         _updateVotingSettings(_votingSettings);
-        if (_minApproval != 0) {
-            _updateMinApproval(_minApproval);
-        }
+        _updateMinApproval(_minApproval);
     }
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.

--- a/packages/contracts/src/MajorityVotingBase.sol
+++ b/packages/contracts/src/MajorityVotingBase.sol
@@ -613,7 +613,7 @@ abstract contract MajorityVotingBase is
     /// @param _votingSettings The voting settings to be validated and updated.
     function _updateVotingSettings(VotingSettings calldata _votingSettings) internal virtual {
         // Require the support threshold value to be in the interval [0, 10^6-1],
-        // because `>` comparision is used in the support criterion and >100% could never be reached.
+        // because `>` comparison is used in the support criterion and >100% could never be reached.
         if (_votingSettings.supportThreshold > RATIO_BASE - 1) {
             revert RatioOutOfBounds({
                 limit: RATIO_BASE - 1,
@@ -622,7 +622,7 @@ abstract contract MajorityVotingBase is
         }
 
         // Require the minimum participation value to be in the interval [0, 10^6],
-        // because `>=` comparision is used in the participation criterion.
+        // because `>=` comparison is used in the participation criterion.
         if (_votingSettings.minParticipation > RATIO_BASE) {
             revert RatioOutOfBounds({limit: RATIO_BASE, actual: _votingSettings.minParticipation});
         }
@@ -649,6 +649,12 @@ abstract contract MajorityVotingBase is
     /// @notice Internal function to update minimal approval value.
     /// @param _minApproval The new minimal approval value.
     function _updateMinApproval(uint32 _minApproval) internal virtual {
+        // Require the minimum approval value to be in the interval [0, 10^6],
+        // because `>=` comparison is used in the participation criterion.
+        if (_minApproval > RATIO_BASE) {
+            revert RatioOutOfBounds({limit: RATIO_BASE, actual: _minApproval});
+        }
+
         minApprovalValue = _minApproval;
         emit VotingMinApprovalUpdated(_minApproval);
     }

--- a/packages/contracts/src/MajorityVotingBase.sol
+++ b/packages/contracts/src/MajorityVotingBase.sol
@@ -304,6 +304,9 @@ abstract contract MajorityVotingBase is
         override(ERC165Upgradeable, PluginUUPSUpgradeable, ProposalUpgradeable)
         returns (bool)
     {
+        // In addition to the current IMajorityVoting interface, also support previous version of the interface that did not
+        // include the isMinApprovalReached() and minApproval() functions, same happens with MAJORITY_VOTING_BASE_INTERFACE_ID which
+        // did not included updateMinApproval() function.
         return
             _interfaceId == MAJORITY_VOTING_BASE_INTERFACE_ID ||
             _interfaceId == MAJORITY_VOTING_BASE_INTERFACE_ID ^ this.updateMinApproval.selector ||

--- a/packages/contracts/src/MajorityVotingBase.sol
+++ b/packages/contracts/src/MajorityVotingBase.sol
@@ -165,6 +165,7 @@ abstract contract MajorityVotingBase is
     /// @param voters The votes casted by the voters.
     /// @param actions The actions to be executed when the proposal passes.
     /// @param allowFailureMap A bitmap allowing the proposal to succeed, even if individual actions might revert.
+    /// @param minApprovalPower The minimum amount of yes votes power needed for the proposal advance.
     /// If the bit at index `i` is 1, the proposal succeeds even if the `i`th action reverts.
     /// A failure map value of 0 requires every action to not revert.
     struct Proposal {
@@ -174,6 +175,7 @@ abstract contract MajorityVotingBase is
         mapping(address => IMajorityVoting.VoteOption) voters;
         IDAO.Action[] actions;
         uint256 allowFailureMap;
+        uint256 minApprovalPower;
     }
 
     /// @notice A container for the proposal parameters at the time of proposal creation.
@@ -211,6 +213,7 @@ abstract contract MajorityVotingBase is
             this.totalVotingPower.selector ^
             this.getProposal.selector ^
             this.updateVotingSettings.selector ^
+            this.updateMinApproval.selector ^
             this.createProposal.selector;
 
     /// @notice The ID of the permission required to call the `updateVotingSettings` function.
@@ -223,6 +226,9 @@ abstract contract MajorityVotingBase is
 
     /// @notice The struct storing the voting settings.
     VotingSettings private votingSettings;
+
+    // todo TBD is this is the best way, can not add it to the voting settings because will break the interface
+    uint32 private minApprovalValue;
 
     /// @notice Thrown if a date is out of bounds.
     /// @param limit The limit value.
@@ -293,7 +299,12 @@ abstract contract MajorityVotingBase is
     {
         return
             _interfaceId == MAJORITY_VOTING_BASE_INTERFACE_ID ||
+            _interfaceId == MAJORITY_VOTING_BASE_INTERFACE_ID ^ this.updateMinApproval.selector ||
             _interfaceId == type(IMajorityVoting).interfaceId ||
+            _interfaceId ==
+            type(IMajorityVoting).interfaceId ^
+                this.isMinApprovalReached.selector ^
+                this.minApproval.selector ||
             super.supportsInterface(_interfaceId);
     }
 
@@ -387,6 +398,17 @@ abstract contract MajorityVotingBase is
     }
 
     /// @inheritdoc IMajorityVoting
+    function isMinApprovalReached(uint256 _proposalId) public view virtual returns (bool) {
+        Proposal storage proposal_ = proposals[_proposalId];
+
+        return proposal_.tally.yes >= proposal_.minApprovalPower;
+    }
+
+    function minApproval() public view virtual returns (uint32) {
+        return minApprovalValue;
+    }
+
+    /// @inheritdoc IMajorityVoting
     function supportThreshold() public view virtual returns (uint32) {
         return votingSettings.supportThreshold;
     }
@@ -458,6 +480,14 @@ abstract contract MajorityVotingBase is
         VotingSettings calldata _votingSettings
     ) external virtual auth(UPDATE_VOTING_SETTINGS_PERMISSION_ID) {
         _updateVotingSettings(_votingSettings);
+    }
+
+    // todo define if permission should be the one as update settings
+    // todo add a new event emission
+    function updateMinApproval(
+        uint32 _minApproval
+    ) external virtual auth(UPDATE_VOTING_SETTINGS_PERMISSION_ID) {
+        minApprovalValue = _minApproval;
     }
 
     /// @notice Creates a new majority voting proposal.
@@ -548,6 +578,10 @@ abstract contract MajorityVotingBase is
             }
         }
         if (!isMinParticipationReached(_proposalId)) {
+            return false;
+        }
+        // ! if the minApproval is zero should ignore it?
+        if (!isMinApprovalReached(_proposalId)) {
             return false;
         }
 
@@ -644,5 +678,6 @@ abstract contract MajorityVotingBase is
     /// new variables without shifting down storage in the inheritance chain
     /// (see [OpenZeppelin's guide about storage gaps]
     /// (https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps)).
-    uint256[47] private __gap;
+    // todo double check the gap is correct
+    uint256[46] private __gap;
 }

--- a/packages/contracts/src/MajorityVotingBase.sol
+++ b/packages/contracts/src/MajorityVotingBase.sol
@@ -227,8 +227,9 @@ abstract contract MajorityVotingBase is
     /// @notice The struct storing the voting settings.
     VotingSettings private votingSettings;
 
-    // todo TBD if this is the best way, can not add it to the voting settings because will break the interface
-    uint32 private minApprovalValue;
+    /// @notice The minimal amount of yes votes needed for a proposal succeed.
+    /// @dev this value is not on the VotingSettings for compatibility reasons.
+    uint32 private minApprovalValue; // added in v1.3
 
     /// @notice Thrown if a date is out of bounds.
     /// @param limit The limit value.

--- a/packages/contracts/src/TokenVoting.sol
+++ b/packages/contracts/src/TokenVoting.sol
@@ -23,7 +23,7 @@ contract TokenVoting is IMembership, MajorityVotingBase {
     using SafeCastUpgradeable for uint256;
 
     /// @notice The [ERC-165](https://eips.ethereum.org/EIPS/eip-165) interface ID of the contract.
-    // todo think if there is a strong reason for keeping the initialize function on the interface id
+    // todo double check there is a strong reason for keeping the initialize function on the interface id
     bytes4 internal constant TOKEN_VOTING_INTERFACE_ID = this.getVotingToken.selector;
     bytes4 internal constant OLD_TOKEN_VOTING_INTERFACE_ID =
         bytes4(keccak256("initialize(address,(uint8,uint32,uint32,uint64,uint256),address)")) ^
@@ -36,11 +36,7 @@ contract TokenVoting is IMembership, MajorityVotingBase {
     /// @notice Thrown if the voting power is zero
     error NoVotingPower();
 
-    /// @notice Initializes the component.
-    /// @dev This method is required to support [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822).
-    /// @param _dao The IDAO interface of the associated DAO.
-    /// @param _votingSettings The voting settings.
-    /// @param _token The [ERC-20](https://eips.ethereum.org/EIPS/eip-20) token used for voting.
+    /// @dev Deprecated function.
     function initialize(
         IDAO _dao,
         VotingSettings calldata _votingSettings,
@@ -50,7 +46,12 @@ contract TokenVoting is IMembership, MajorityVotingBase {
         _initialize(_dao, _votingSettings, _token, 0);
     }
 
-    // todo natspec
+    /// @notice Initializes the component.
+    /// @dev This method is required to support [ERC-1822](https://eips.ethereum.org/EIPS/eip-1822).
+    /// @param _dao The IDAO interface of the associated DAO.
+    /// @param _votingSettings The voting settings.
+    /// @param _token The [ERC-20](https://eips.ethereum.org/EIPS/eip-20) token used for voting.
+    /// @param _minApproval The minimal amount of approvals the proposal needs to succeed.
     function initialize(
         IDAO _dao,
         VotingSettings calldata _votingSettings,
@@ -60,7 +61,8 @@ contract TokenVoting is IMembership, MajorityVotingBase {
         _initialize(_dao, _votingSettings, _token, _minApproval);
     }
 
-    // todo natspec
+    /// @notice Initializes the plugin after an upgrade from a previous version.
+    /// @param _minApproval The minimal amount of approvals the proposal needs to succeed.
     function initializeFrom(uint32 _minApproval) external reinitializer(2) {
         _updateMinApproval(_minApproval);
     }
@@ -181,7 +183,7 @@ contract TokenVoting is IMembership, MajorityVotingBase {
             IERC20Upgradeable(address(votingToken)).balanceOf(_account) > 0;
     }
 
-    // todo natspec
+    /// @dev Internal function to initialize the contract.
     function _initialize(
         IDAO _dao,
         VotingSettings calldata _votingSettings,

--- a/packages/contracts/src/TokenVoting.sol
+++ b/packages/contracts/src/TokenVoting.sol
@@ -36,14 +36,18 @@ contract TokenVoting is IMembership, MajorityVotingBase {
     /// @notice Thrown if the voting power is zero
     error NoVotingPower();
 
+    error FunctionDeprecated();
+
     /// @dev Deprecated function.
     function initialize(
         IDAO _dao,
         VotingSettings calldata _votingSettings,
         IVotesUpgradeable _token
     ) external initializer {
-        // todo TBD should we deprecate this function?
-        _initialize(_dao, _votingSettings, _token, 0);
+        (_dao, _votingSettings, _token);
+
+        // todo TBD should we deprecate this function or only continue with old flow?
+        revert FunctionDeprecated();
     }
 
     /// @notice Initializes the component.
@@ -58,7 +62,11 @@ contract TokenVoting is IMembership, MajorityVotingBase {
         IVotesUpgradeable _token,
         uint32 _minApproval
     ) external initializer {
-        _initialize(_dao, _votingSettings, _token, _minApproval);
+        __MajorityVotingBase_init(_dao, _votingSettings, _minApproval);
+
+        votingToken = _token;
+
+        emit MembershipContractAnnounced({definingContract: address(_token)});
     }
 
     /// @notice Initializes the plugin after an upgrade from a previous version.
@@ -181,20 +189,6 @@ contract TokenVoting is IMembership, MajorityVotingBase {
         return
             votingToken.getVotes(_account) > 0 ||
             IERC20Upgradeable(address(votingToken)).balanceOf(_account) > 0;
-    }
-
-    /// @dev Internal function to initialize the contract.
-    function _initialize(
-        IDAO _dao,
-        VotingSettings calldata _votingSettings,
-        IVotesUpgradeable _token,
-        uint32 _minApproval
-    ) internal {
-        __MajorityVotingBase_init(_dao, _votingSettings, _minApproval);
-
-        votingToken = _token;
-
-        emit MembershipContractAnnounced({definingContract: address(_token)});
     }
 
     /// @inheritdoc MajorityVotingBase

--- a/packages/contracts/src/TokenVoting.sol
+++ b/packages/contracts/src/TokenVoting.sol
@@ -60,7 +60,7 @@ contract TokenVoting is IMembership, MajorityVotingBase {
         IDAO _dao,
         VotingSettings calldata _votingSettings,
         IVotesUpgradeable _token,
-        uint32 _minApprovals
+        uint256 _minApprovals
     ) external initializer {
         __MajorityVotingBase_init(_dao, _votingSettings, _minApprovals);
 
@@ -71,7 +71,7 @@ contract TokenVoting is IMembership, MajorityVotingBase {
 
     /// @notice Initializes the plugin after an upgrade from a previous version.
     /// @param _minApprovals The minimal amount of approvals the proposal needs to succeed.
-    function initializeFrom(uint32 _minApprovals) external reinitializer(2) {
+    function initializeFrom(uint256 _minApprovals) external reinitializer(2) {
         _updateMinApprovals(_minApprovals);
     }
 

--- a/packages/contracts/src/TokenVoting.sol
+++ b/packages/contracts/src/TokenVoting.sol
@@ -163,7 +163,6 @@ contract TokenVoting is IMembership, MajorityVotingBase {
             minParticipation()
         );
 
-        // todo double check this, what if the minApproval is 0?
         proposal_.minApprovalPower = _applyRatioCeiled(totalVotingPower_, minApproval());
 
         // Reduce costs

--- a/packages/contracts/src/TokenVoting.sol
+++ b/packages/contracts/src/TokenVoting.sol
@@ -23,8 +23,11 @@ contract TokenVoting is IMembership, MajorityVotingBase {
     using SafeCastUpgradeable for uint256;
 
     /// @notice The [ERC-165](https://eips.ethereum.org/EIPS/eip-165) interface ID of the contract.
-    bytes4 internal constant TOKEN_VOTING_INTERFACE_ID =
-        this.initialize.selector ^ this.getVotingToken.selector;
+    // todo think if there is a strong reason for keeping the initialize function on the interface id
+    bytes4 internal constant TOKEN_VOTING_INTERFACE_ID = this.getVotingToken.selector;
+    bytes4 internal constant OLD_TOKEN_VOTING_INTERFACE_ID =
+        bytes4(keccak256("initialize(address,(uint8,uint32,uint32,uint64,uint256),address)")) ^
+            this.getVotingToken.selector;
 
     /// @notice An [OpenZeppelin `Votes`](https://docs.openzeppelin.com/contracts/4.x/api/governance#Votes)
     /// compatible contract referencing the token being used for voting.
@@ -43,11 +46,23 @@ contract TokenVoting is IMembership, MajorityVotingBase {
         VotingSettings calldata _votingSettings,
         IVotesUpgradeable _token
     ) external initializer {
-        __MajorityVotingBase_init(_dao, _votingSettings);
+        // todo TBD should we deprecate this function?
+        _initialize(_dao, _votingSettings, _token, 0);
+    }
 
-        votingToken = _token;
+    // todo natspec
+    function initialize(
+        IDAO _dao,
+        VotingSettings calldata _votingSettings,
+        IVotesUpgradeable _token,
+        uint32 _minApproval
+    ) external initializer {
+        _initialize(_dao, _votingSettings, _token, _minApproval);
+    }
 
-        emit MembershipContractAnnounced({definingContract: address(_token)});
+    // todo natspec
+    function initializeFrom(uint32 _minApproval) external reinitializer(2) {
+        _updateMinApproval(_minApproval);
     }
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
@@ -56,6 +71,7 @@ contract TokenVoting is IMembership, MajorityVotingBase {
     function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         return
             _interfaceId == TOKEN_VOTING_INTERFACE_ID ||
+            _interfaceId == OLD_TOKEN_VOTING_INTERFACE_ID ||
             _interfaceId == type(IMembership).interfaceId ||
             super.supportsInterface(_interfaceId);
     }
@@ -137,6 +153,9 @@ contract TokenVoting is IMembership, MajorityVotingBase {
             minParticipation()
         );
 
+        // todo double check this, what if the minApproval is 0?
+        proposal_.minApprovalPower = _applyRatioCeiled(totalVotingPower_, minApproval());
+
         // Reduce costs
         if (_allowFailureMap != 0) {
             proposal_.allowFailureMap = _allowFailureMap;
@@ -160,6 +179,20 @@ contract TokenVoting is IMembership, MajorityVotingBase {
         return
             votingToken.getVotes(_account) > 0 ||
             IERC20Upgradeable(address(votingToken)).balanceOf(_account) > 0;
+    }
+
+    // todo natspec
+    function _initialize(
+        IDAO _dao,
+        VotingSettings calldata _votingSettings,
+        IVotesUpgradeable _token,
+        uint32 _minApproval
+    ) internal {
+        __MajorityVotingBase_init(_dao, _votingSettings, _minApproval);
+
+        votingToken = _token;
+
+        emit MembershipContractAnnounced({definingContract: address(_token)});
     }
 
     /// @inheritdoc MajorityVotingBase

--- a/packages/contracts/src/TokenVoting.sol
+++ b/packages/contracts/src/TokenVoting.sol
@@ -72,7 +72,7 @@ contract TokenVoting is IMembership, MajorityVotingBase {
     /// @notice Initializes the plugin after an upgrade from a previous version.
     /// @param _minApprovals The minimal amount of approvals the proposal needs to succeed.
     function initializeFrom(uint32 _minApprovals) external reinitializer(2) {
-        _updateMinApproval(_minApprovals);
+        _updateMinApprovals(_minApprovals);
     }
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.

--- a/packages/contracts/src/TokenVoting.sol
+++ b/packages/contracts/src/TokenVoting.sol
@@ -55,14 +55,14 @@ contract TokenVoting is IMembership, MajorityVotingBase {
     /// @param _dao The IDAO interface of the associated DAO.
     /// @param _votingSettings The voting settings.
     /// @param _token The [ERC-20](https://eips.ethereum.org/EIPS/eip-20) token used for voting.
-    /// @param _minApproval The minimal amount of approvals the proposal needs to succeed.
+    /// @param _minApprovals The minimal amount of approvals the proposal needs to succeed.
     function initialize(
         IDAO _dao,
         VotingSettings calldata _votingSettings,
         IVotesUpgradeable _token,
-        uint32 _minApproval
+        uint32 _minApprovals
     ) external initializer {
-        __MajorityVotingBase_init(_dao, _votingSettings, _minApproval);
+        __MajorityVotingBase_init(_dao, _votingSettings, _minApprovals);
 
         votingToken = _token;
 
@@ -70,9 +70,9 @@ contract TokenVoting is IMembership, MajorityVotingBase {
     }
 
     /// @notice Initializes the plugin after an upgrade from a previous version.
-    /// @param _minApproval The minimal amount of approvals the proposal needs to succeed.
-    function initializeFrom(uint32 _minApproval) external reinitializer(2) {
-        _updateMinApproval(_minApproval);
+    /// @param _minApprovals The minimal amount of approvals the proposal needs to succeed.
+    function initializeFrom(uint32 _minApprovals) external reinitializer(2) {
+        _updateMinApproval(_minApprovals);
     }
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.

--- a/packages/contracts/src/TokenVotingSetup.sol
+++ b/packages/contracts/src/TokenVotingSetup.sol
@@ -97,14 +97,14 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
             TokenSettings memory tokenSettings,
             // only used for GovernanceERC20(token is not passed)
             GovernanceERC20.MintSettings memory mintSettings,
-            uint32 minApprovals
+            uint256 minApprovals
         ) = abi.decode(
                 _data,
                 (
                     MajorityVotingBase.VotingSettings,
                     TokenSettings,
                     GovernanceERC20.MintSettings,
-                    uint32
+                    uint256
                 )
             );
 
@@ -161,7 +161,7 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
         // Prepare and deploy plugin proxy.
         plugin = address(tokenVotingBase).deployUUPSProxy(
             abi.encodeWithSignature(
-                "initialize(address,(uint8,uint32,uint32,uint64,uint256),address,uint32)",
+                "initialize(address,(uint8,uint32,uint32,uint64,uint256),address,uint256)",
                 IDAO(_dao),
                 votingSettings,
                 IVotesUpgradeable(token),
@@ -239,7 +239,7 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
             // initialize the minAdvance value
             initData = abi.encodeCall(
                 TokenVoting.initializeFrom,
-                (abi.decode(_payload.data, (uint32)))
+                (abi.decode(_payload.data, (uint256)))
             );
         }
     }

--- a/packages/contracts/src/TokenVotingSetup.sol
+++ b/packages/contracts/src/TokenVotingSetup.sol
@@ -162,7 +162,7 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
         plugin = address(tokenVotingBase).deployUUPSProxy(
             // todo change to new initialize function
             abi.encodeWithSignature(
-                "initialize(address,(uint8,uint32,uint32,uint64,uint256),address, uint32)",
+                "initialize(address,(uint8,uint32,uint32,uint64,uint256),address,uint32)",
                 IDAO(_dao),
                 votingSettings,
                 IVotesUpgradeable(token),

--- a/packages/contracts/src/TokenVotingSetup.sol
+++ b/packages/contracts/src/TokenVotingSetup.sol
@@ -160,7 +160,6 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
 
         // Prepare and deploy plugin proxy.
         plugin = address(tokenVotingBase).deployUUPSProxy(
-            // todo change to new initialize function
             abi.encodeWithSignature(
                 "initialize(address,(uint8,uint32,uint32,uint64,uint256),address,uint32)",
                 IDAO(_dao),

--- a/packages/contracts/src/TokenVotingSetup.sol
+++ b/packages/contracts/src/TokenVotingSetup.sol
@@ -154,9 +154,12 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
 
         // Prepare and deploy plugin proxy.
         plugin = address(tokenVotingBase).deployUUPSProxy(
-            abi.encodeCall(
-                TokenVoting.initialize,
-                (IDAO(_dao), votingSettings, IVotesUpgradeable(token))
+            // todo change to new initialize function
+            abi.encodeWithSignature(
+                "initialize(address,(uint8,uint32,uint32,uint64,uint256),address)",
+                IDAO(_dao),
+                votingSettings,
+                IVotesUpgradeable(token)
             )
         );
 

--- a/packages/contracts/src/TokenVotingSetup.sol
+++ b/packages/contracts/src/TokenVotingSetup.sol
@@ -96,10 +96,16 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
             MajorityVotingBase.VotingSettings memory votingSettings,
             TokenSettings memory tokenSettings,
             // only used for GovernanceERC20(token is not passed)
-            GovernanceERC20.MintSettings memory mintSettings
+            GovernanceERC20.MintSettings memory mintSettings,
+            uint32 minApproval
         ) = abi.decode(
                 _data,
-                (MajorityVotingBase.VotingSettings, TokenSettings, GovernanceERC20.MintSettings)
+                (
+                    MajorityVotingBase.VotingSettings,
+                    TokenSettings,
+                    GovernanceERC20.MintSettings,
+                    uint32
+                )
             );
 
         address token = tokenSettings.addr;
@@ -156,10 +162,11 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
         plugin = address(tokenVotingBase).deployUUPSProxy(
             // todo change to new initialize function
             abi.encodeWithSignature(
-                "initialize(address,(uint8,uint32,uint32,uint64,uint256),address)",
+                "initialize(address,(uint8,uint32,uint32,uint64,uint256),address, uint32)",
                 IDAO(_dao),
                 votingSettings,
-                IVotesUpgradeable(token)
+                IVotesUpgradeable(token),
+                minApproval
             )
         );
 
@@ -216,7 +223,6 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
         override
         returns (bytes memory initData, PreparedSetupData memory preparedSetupData)
     {
-        (initData);
         if (_fromBuild < 3) {
             PermissionLib.MultiTargetPermission[]
                 memory permissions = new PermissionLib.MultiTargetPermission[](1);
@@ -230,6 +236,12 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
             });
 
             preparedSetupData.permissions = permissions;
+
+            // initialize the minAdvance value
+            initData = abi.encodeCall(
+                TokenVoting.initializeFrom,
+                (abi.decode(_payload.data, (uint32)))
+            );
         }
     }
 

--- a/packages/contracts/src/TokenVotingSetup.sol
+++ b/packages/contracts/src/TokenVotingSetup.sol
@@ -97,7 +97,7 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
             TokenSettings memory tokenSettings,
             // only used for GovernanceERC20(token is not passed)
             GovernanceERC20.MintSettings memory mintSettings,
-            uint32 minApproval
+            uint32 minApprovals
         ) = abi.decode(
                 _data,
                 (
@@ -165,7 +165,7 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
                 IDAO(_dao),
                 votingSettings,
                 IVotesUpgradeable(token),
-                minApproval
+                minApprovals
             )
         );
 

--- a/packages/contracts/src/build-metadata.json
+++ b/packages/contracts/src/build-metadata.json
@@ -88,6 +88,12 @@
           "name": "mintSettings",
           "type": "tuple",
           "description": "The token mint settings struct containing the `receivers` and `amounts`."
+        },
+        {
+          "internalType": "uint32",
+          "name": "minApproval",
+          "type": "uint32",
+          "description": "The minimum amount of yes votes needed for the proposal advance."
         }
       ]
     },
@@ -99,6 +105,17 @@
       "2": {
         "description": "No input is required for the update.",
         "inputs": []
+      },
+      "3": {
+        "description": "No input is required for the update.",
+        "inputs": [
+          {
+            "internalType": "uint32",
+            "name": "minApproval",
+            "type": "uint32",
+            "description": "The minimum amount of yes votes needed for the proposal advance."
+          }
+        ]
       }
     },
     "prepareUninstallation": {

--- a/packages/contracts/src/build-metadata.json
+++ b/packages/contracts/src/build-metadata.json
@@ -107,7 +107,7 @@
         "inputs": []
       },
       "3": {
-        "description": "No input is required for the update.",
+        "description": "The information required for the installation.",
         "inputs": [
           {
             "internalType": "uint32",

--- a/packages/contracts/src/mocks/MajorityVotingMock.sol
+++ b/packages/contracts/src/mocks/MajorityVotingMock.sol
@@ -8,9 +8,9 @@ contract MajorityVotingMock is MajorityVotingBase {
     function initializeMock(
         IDAO _dao,
         VotingSettings calldata _votingSettings,
-        uint32 _minApproval
+        uint32 _minApprovals
     ) public initializer {
-        __MajorityVotingBase_init(_dao, _votingSettings, _minApproval);
+        __MajorityVotingBase_init(_dao, _votingSettings, _minApprovals);
     }
 
     function createProposal(

--- a/packages/contracts/src/mocks/MajorityVotingMock.sol
+++ b/packages/contracts/src/mocks/MajorityVotingMock.sol
@@ -8,7 +8,7 @@ contract MajorityVotingMock is MajorityVotingBase {
     function initializeMock(
         IDAO _dao,
         VotingSettings calldata _votingSettings,
-        uint32 _minApprovals
+        uint256 _minApprovals
     ) public initializer {
         __MajorityVotingBase_init(_dao, _votingSettings, _minApprovals);
     }

--- a/packages/contracts/src/mocks/MajorityVotingMock.sol
+++ b/packages/contracts/src/mocks/MajorityVotingMock.sol
@@ -5,8 +5,12 @@ pragma solidity ^0.8.8;
 import {MajorityVotingBase, IDAO} from "../MajorityVotingBase.sol";
 
 contract MajorityVotingMock is MajorityVotingBase {
-    function initializeMock(IDAO _dao, VotingSettings calldata _votingSettings) public initializer {
-        __MajorityVotingBase_init(_dao, _votingSettings, 0);
+    function initializeMock(
+        IDAO _dao,
+        VotingSettings calldata _votingSettings,
+        uint32 _minApproval
+    ) public initializer {
+        __MajorityVotingBase_init(_dao, _votingSettings, _minApproval);
     }
 
     function createProposal(

--- a/packages/contracts/src/mocks/MajorityVotingMock.sol
+++ b/packages/contracts/src/mocks/MajorityVotingMock.sol
@@ -6,7 +6,7 @@ import {MajorityVotingBase, IDAO} from "../MajorityVotingBase.sol";
 
 contract MajorityVotingMock is MajorityVotingBase {
     function initializeMock(IDAO _dao, VotingSettings calldata _votingSettings) public initializer {
-        __MajorityVotingBase_init(_dao, _votingSettings);
+        __MajorityVotingBase_init(_dao, _votingSettings, 0);
     }
 
     function createProposal(

--- a/packages/contracts/test/10_unit-testing/11_plugin.ts
+++ b/packages/contracts/test/10_unit-testing/11_plugin.ts
@@ -123,7 +123,7 @@ async function globalFixture(): Promise<GlobalFixtureResult> {
   };
 
   const pluginInitdata = pluginImplementation.interface.encodeFunctionData(
-    'initialize',
+    'initialize(address,(uint8,uint32,uint32,uint64,uint256),address)',
     [dao.address, defaultVotingSettings, token.address]
   );
   const deploymentTx1 = await proxyFactory.deployUUPSProxy(pluginInitdata);
@@ -205,11 +205,9 @@ describe('TokenVoting', function () {
 
       // Try to reinitialize the initialized plugin.
       await expect(
-        initializedPlugin.initialize(
-          dao.address,
-          defaultVotingSettings,
-          token.address
-        )
+        initializedPlugin[
+          'initialize(address,(uint8,uint32,uint32,uint64,uint256),address)'
+        ](dao.address, defaultVotingSettings, token.address)
       ).to.be.revertedWith('Initializable: contract is already initialized');
     });
 
@@ -219,11 +217,9 @@ describe('TokenVoting', function () {
 
       // Initialize the uninitialized plugin.
       await expect(
-        await uninitializedPlugin.initialize(
-          dao.address,
-          defaultVotingSettings,
-          token.address
-        )
+        await uninitializedPlugin[
+          'initialize(address,(uint8,uint32,uint32,uint64,uint256),address)'
+        ](dao.address, defaultVotingSettings, token.address)
       )
         .to.emit(uninitializedPlugin, 'MembershipContractAnnounced')
         .withArgs(token.address);
@@ -256,7 +252,9 @@ describe('TokenVoting', function () {
       };
 
       // Initialize the plugin.
-      await plugin.initialize(dao.address, votingSettings, token.address);
+      await plugin[
+        'initialize(address,(uint8,uint32,uint32,uint64,uint256),address)'
+      ](dao.address, votingSettings, token.address);
 
       // Check that the voting settings have been set.
       expect(await plugin.minDuration()).to.equal(votingSettings.minDuration);

--- a/packages/contracts/test/10_unit-testing/11_plugin.ts
+++ b/packages/contracts/test/10_unit-testing/11_plugin.ts
@@ -2884,7 +2884,7 @@ describe('TokenVoting', function () {
       });
     });
 
-    describe('An edge case with `supportThreshold = 0%`, `minParticipation = 0%`, in early execution mode', async () => {
+    describe('An edge case with `supportThreshold = 0%`, `minParticipation = 0%`, `minApproval = 0%` in early execution mode', async () => {
       type LocalFixtureResult = {
         deployer: SignerWithAddress;
         alice: SignerWithAddress;
@@ -2919,9 +2919,15 @@ describe('TokenVoting', function () {
           minProposerVotingPower: 0,
         };
 
+        const minApproval = pctToRatio(0);
+
         await initializedPlugin
           .connect(deployer)
           .updateVotingSettings(newVotingSettings);
+
+        await initializedPlugin
+          .connect(deployer)
+          .updateMinApproval(minApproval);
 
         return {
           deployer,
@@ -2967,7 +2973,7 @@ describe('TokenVoting', function () {
         expect(await plugin.canExecute(id)).to.equal(false);
       });
 
-      it('executes if participation and support are met', async () => {
+      it('executes if participation, support and min approval are met', async () => {
         const {
           alice,
           initializedPlugin: plugin,
@@ -3003,7 +3009,7 @@ describe('TokenVoting', function () {
       });
     });
 
-    describe('An edge case with `supportThreshold = 99.9999%` and `minParticipation = 100%` in early execution mode', async () => {
+    describe('An edge case with `supportThreshold = 99.9999%`, `minParticipation = 100%` and `minApproval = 100%` in early execution mode', async () => {
       describe('token balances are in the magnitude of 10^18', async () => {
         type LocalFixtureResult = {
           deployer: SignerWithAddress;
@@ -3052,9 +3058,15 @@ describe('TokenVoting', function () {
             minProposerVotingPower: 0,
           };
 
+          const minApproval = pctToRatio(100); // the largest possible value
+
           await initializedPlugin
             .connect(deployer)
             .updateVotingSettings(newVotingSettings);
+
+          await initializedPlugin
+            .connect(deployer)
+            .updateMinApproval(minApproval);
 
           return {
             deployer,

--- a/packages/contracts/test/10_unit-testing/11_plugin.ts
+++ b/packages/contracts/test/10_unit-testing/11_plugin.ts
@@ -317,7 +317,7 @@ describe('TokenVoting', function () {
       // Check that the token has been set.
       expect(await plugin.getVotingToken()).to.equal(token.address);
 
-      // Check the minimal approval have been set.
+      // Check the minimal approval has been set.
       expect(await plugin.minApproval()).to.equal(minApproval);
     });
   });
@@ -2625,7 +2625,6 @@ describe('TokenVoting', function () {
         };
 
         const newMinApproval = pctToRatio(21);
-        console.log('newMinApproval', newMinApproval);
 
         await initializedPlugin
           .connect(deployer)

--- a/packages/contracts/test/10_unit-testing/11_plugin.ts
+++ b/packages/contracts/test/10_unit-testing/11_plugin.ts
@@ -25,6 +25,8 @@ import {
 import {
   TOKEN_VOTING_INTERFACE,
   UPDATE_VOTING_SETTINGS_PERMISSION_ID,
+  INITIALIZE_SIGNATURE,
+  INITIALIZE_SIGNATURE_OLD,
 } from '../test-utils/token-voting-constants';
 import {
   TokenVoting__factory,
@@ -129,7 +131,7 @@ async function globalFixture(): Promise<GlobalFixtureResult> {
   const defaultMinApproval = pctToRatio(10);
 
   const pluginInitData = pluginImplementation.interface.encodeFunctionData(
-    'initialize(address,(uint8,uint32,uint32,uint64,uint256),address,uint32)',
+    INITIALIZE_SIGNATURE,
     [dao.address, defaultVotingSettings, token.address, defaultMinApproval]
   );
   const deploymentTx1 = await proxyFactory.deployUUPSProxy(pluginInitData);
@@ -217,10 +219,30 @@ describe('TokenVoting', function () {
 
       // Try to reinitialize the initialized plugin.
       await expect(
-        initializedPlugin[
-          'initialize(address,(uint8,uint32,uint32,uint64,uint256),address,uint32)'
-        ](dao.address, defaultVotingSettings, token.address, defaultMinApproval)
+        initializedPlugin[INITIALIZE_SIGNATURE](
+          dao.address,
+          defaultVotingSettings,
+          token.address,
+          defaultMinApproval
+        )
       ).to.be.revertedWith('Initializable: contract is already initialized');
+    });
+
+    it('reverts if using DEPRECATED intialize function', async () => {
+      const {dao, uninitializedPlugin, defaultVotingSettings, token} =
+        await loadFixture(globalFixture);
+
+      // Try to call deprecated function (previous function with no minApproval param)
+      await expect(
+        uninitializedPlugin[INITIALIZE_SIGNATURE_OLD](
+          dao.address,
+          defaultVotingSettings,
+          token.address
+        )
+      ).to.be.revertedWithCustomError(
+        uninitializedPlugin,
+        'FunctionDeprecated'
+      );
     });
 
     it('emits the `MembershipContractAnnounced` event', async () => {
@@ -234,9 +256,12 @@ describe('TokenVoting', function () {
 
       // Initialize the uninitialized plugin.
       await expect(
-        await uninitializedPlugin[
-          'initialize(address,(uint8,uint32,uint32,uint64,uint256),address,uint32)'
-        ](dao.address, defaultVotingSettings, token.address, defaultMinApproval)
+        await uninitializedPlugin[INITIALIZE_SIGNATURE](
+          dao.address,
+          defaultVotingSettings,
+          token.address,
+          defaultMinApproval
+        )
       )
         .to.emit(uninitializedPlugin, 'MembershipContractAnnounced')
         .withArgs(token.address);
@@ -270,9 +295,12 @@ describe('TokenVoting', function () {
       const minApproval = pctToRatio(30);
 
       // Initialize the plugin.
-      await plugin[
-        'initialize(address,(uint8,uint32,uint32,uint64,uint256),address,uint32)'
-      ](dao.address, votingSettings, token.address, minApproval);
+      await plugin[INITIALIZE_SIGNATURE](
+        dao.address,
+        votingSettings,
+        token.address,
+        minApproval
+      );
 
       // Check that the voting settings have been set.
       expect(await plugin.minDuration()).to.equal(votingSettings.minDuration);

--- a/packages/contracts/test/10_unit-testing/11_plugin.ts
+++ b/packages/contracts/test/10_unit-testing/11_plugin.ts
@@ -126,7 +126,7 @@ async function globalFixture(): Promise<GlobalFixtureResult> {
   };
 
   // todo set a different value
-  const defaultMinApproval = pctToRatio(80);
+  const defaultMinApproval = pctToRatio(10);
 
   const pluginInitdata = pluginImplementation.interface.encodeFunctionData(
     'initialize(address,(uint8,uint32,uint32,uint64,uint256),address,uint32)',
@@ -267,7 +267,7 @@ describe('TokenVoting', function () {
         minDuration: TIME.HOUR,
         minProposerVotingPower: 123,
       };
-      const minApproval = pctToRatio(80);
+      const minApproval = pctToRatio(30);
 
       // Initialize the plugin.
       await plugin[

--- a/packages/contracts/test/10_unit-testing/11_plugin.ts
+++ b/packages/contracts/test/10_unit-testing/11_plugin.ts
@@ -19,6 +19,7 @@ import {
 import {ExecutedEvent} from '../../typechain/src/mocks/DAOMock';
 import {
   MAJORITY_VOTING_BASE_INTERFACE,
+  MAJORITY_VOTING_BASE_OLD_INTERFACE,
   VOTING_EVENTS,
 } from '../test-utils/majority-voting-constants';
 import {
@@ -28,6 +29,7 @@ import {
 import {
   TokenVoting__factory,
   TokenVoting,
+  IMajorityVoting_V1_3_0__factory,
 } from '../test-utils/typechain-versions';
 import {
   VoteOption,
@@ -69,6 +71,7 @@ type GlobalFixtureResult = {
   initializedPlugin: TokenVoting;
   uninitializedPlugin: TokenVoting;
   defaultVotingSettings: MajorityVotingBase.VotingSettingsStruct;
+  defaultMinApproval: BigNumber;
   token: TestGovernanceERC20;
   dao: DAO;
   dummyActions: DAOStructs.ActionStruct[];
@@ -122,9 +125,12 @@ async function globalFixture(): Promise<GlobalFixtureResult> {
     minProposerVotingPower: 0,
   };
 
+  // todo set a different value
+  const defaultMinApproval = pctToRatio(80);
+
   const pluginInitdata = pluginImplementation.interface.encodeFunctionData(
-    'initialize(address,(uint8,uint32,uint32,uint64,uint256),address)',
-    [dao.address, defaultVotingSettings, token.address]
+    'initialize(address,(uint8,uint32,uint32,uint64,uint256),address,uint32)',
+    [dao.address, defaultVotingSettings, token.address, defaultMinApproval]
   );
   const deploymentTx1 = await proxyFactory.deployUUPSProxy(pluginInitdata);
   const proxyCreatedEvent1 = findEvent<ProxyCreatedEvent>(
@@ -190,6 +196,7 @@ async function globalFixture(): Promise<GlobalFixtureResult> {
     initializedPlugin,
     uninitializedPlugin,
     defaultVotingSettings,
+    defaultMinApproval,
     token,
     dao,
     dummyActions,
@@ -200,32 +207,42 @@ async function globalFixture(): Promise<GlobalFixtureResult> {
 describe('TokenVoting', function () {
   describe('initialize', async () => {
     it('reverts if trying to re-initialize', async () => {
-      const {dao, initializedPlugin, defaultVotingSettings, token} =
-        await loadFixture(globalFixture);
+      const {
+        dao,
+        initializedPlugin,
+        defaultVotingSettings,
+        defaultMinApproval,
+        token,
+      } = await loadFixture(globalFixture);
 
       // Try to reinitialize the initialized plugin.
       await expect(
         initializedPlugin[
-          'initialize(address,(uint8,uint32,uint32,uint64,uint256),address)'
-        ](dao.address, defaultVotingSettings, token.address)
+          'initialize(address,(uint8,uint32,uint32,uint64,uint256),address,uint32)'
+        ](dao.address, defaultVotingSettings, token.address, defaultMinApproval)
       ).to.be.revertedWith('Initializable: contract is already initialized');
     });
 
     it('emits the `MembershipContractAnnounced` event', async () => {
-      const {dao, uninitializedPlugin, defaultVotingSettings, token} =
-        await loadFixture(globalFixture);
+      const {
+        dao,
+        uninitializedPlugin,
+        defaultVotingSettings,
+        defaultMinApproval,
+        token,
+      } = await loadFixture(globalFixture);
 
       // Initialize the uninitialized plugin.
       await expect(
         await uninitializedPlugin[
-          'initialize(address,(uint8,uint32,uint32,uint64,uint256),address)'
-        ](dao.address, defaultVotingSettings, token.address)
+          'initialize(address,(uint8,uint32,uint32,uint64,uint256),address,uint32)'
+        ](dao.address, defaultVotingSettings, token.address, defaultMinApproval)
       )
         .to.emit(uninitializedPlugin, 'MembershipContractAnnounced')
         .withArgs(token.address);
     });
 
-    it('sets the voting settings and token', async () => {
+    it('sets the voting settings, token and minimal approval', async () => {
       const {
         dao,
         uninitializedPlugin: plugin,
@@ -250,11 +267,12 @@ describe('TokenVoting', function () {
         minDuration: TIME.HOUR,
         minProposerVotingPower: 123,
       };
+      const minApproval = pctToRatio(80);
 
       // Initialize the plugin.
       await plugin[
-        'initialize(address,(uint8,uint32,uint32,uint64,uint256),address)'
-      ](dao.address, votingSettings, token.address);
+        'initialize(address,(uint8,uint32,uint32,uint64,uint256),address,uint32)'
+      ](dao.address, votingSettings, token.address, minApproval);
 
       // Check that the voting settings have been set.
       expect(await plugin.minDuration()).to.equal(votingSettings.minDuration);
@@ -271,6 +289,9 @@ describe('TokenVoting', function () {
 
       // Check that the token has been set.
       expect(await plugin.getVotingToken()).to.equal(token.address);
+
+      // Check the minimal approval have been set.
+      expect(await plugin.minApproval()).to.equal(minApproval);
     });
   });
 
@@ -316,11 +337,28 @@ describe('TokenVoting', function () {
       expect(await plugin.supportsInterface(getInterfaceId(iface))).to.be.true;
     });
 
+    it('supports the `IMajorityVoting` OLD interface', async () => {
+      const {initializedPlugin: plugin} = await loadFixture(globalFixture);
+      // const iface = IMajorityVoting__factory.createInterface();
+      const oldIface = IMajorityVoting_V1_3_0__factory.createInterface();
+      expect(await plugin.supportsInterface(getInterfaceId(oldIface))).to.be
+        .true;
+    });
+
     it('supports the `MajorityVotingBase` interface', async () => {
       const {initializedPlugin: plugin} = await loadFixture(globalFixture);
       expect(
         await plugin.supportsInterface(
           getInterfaceId(MAJORITY_VOTING_BASE_INTERFACE)
+        )
+      ).to.be.true;
+    });
+
+    it('supports the `MajorityVotingBase` OLD interface', async () => {
+      const {initializedPlugin: plugin} = await loadFixture(globalFixture);
+      expect(
+        await plugin.supportsInterface(
+          getInterfaceId(MAJORITY_VOTING_BASE_OLD_INTERFACE)
         )
       ).to.be.true;
     });
@@ -735,7 +773,7 @@ describe('TokenVoting', function () {
         ).not.to.be.reverted;
       });
 
-      it('reverts if `_msgSender` doesn not own enough tokens herself/himself and has not tokens delegated to her/him in the current block', async () => {
+      it('reverts if `_msgSender` does not own enough tokens herself/himself and has not tokens delegated to her/him in the current block', async () => {
         const {
           deployer,
           alice,
@@ -2493,7 +2531,7 @@ describe('TokenVoting', function () {
   });
 
   describe('Different configurations:', async () => {
-    describe('A simple majority vote with >50% support and >=25% participation required', async () => {
+    describe('A simple majority vote with >50% support, >=25% participation required and minimal approval >= 21%', async () => {
       type LocalFixtureResult = {
         deployer: SignerWithAddress;
         alice: SignerWithAddress;
@@ -2560,9 +2598,16 @@ describe('TokenVoting', function () {
           minProposerVotingPower: 0,
         };
 
+        const newMinApproval = pctToRatio(21);
+        console.log('newMinApproval', newMinApproval);
+
         await initializedPlugin
           .connect(deployer)
           .updateVotingSettings(newVotingSettings);
+
+        await initializedPlugin
+          .connect(deployer)
+          .updateMinApproval(newMinApproval);
 
         return {
           deployer,
@@ -2621,6 +2666,50 @@ describe('TokenVoting', function () {
         expect(await plugin.canExecute(id)).to.equal(false);
       });
 
+      it('does not execute if support and participation are high enough but minimal approval is too low', async () => {
+        const {
+          alice,
+          bob,
+          carol,
+          initializedPlugin: plugin,
+          dummyMetadata,
+          dummyActions,
+        } = await loadFixture(localFixture);
+
+        const endDate = (await time.latest()) + TIME.DAY;
+
+        await plugin.createProposal(
+          dummyMetadata,
+          dummyActions,
+          0,
+          0,
+          endDate,
+          VoteOption.None,
+          false
+        );
+        const id = 0;
+
+        await voteWithSigners(plugin, id, {
+          yes: [alice, carol], // 20 votes
+          no: [bob], //  10 votes
+          abstain: [], // 0 votes
+        });
+
+        expect(await plugin.isMinParticipationReached(id)).to.be.true;
+        expect(await plugin.isSupportThresholdReachedEarly(id)).to.be.false;
+        expect(await plugin.isMinApprovalReached(id)).to.be.false;
+
+        expect(await plugin.canExecute(id)).to.be.false;
+
+        await time.increaseTo(endDate);
+
+        expect(await plugin.isMinParticipationReached(id)).to.be.true;
+        expect(await plugin.isSupportThresholdReached(id)).to.be.true;
+        expect(await plugin.isMinApprovalReached(id)).to.be.false;
+
+        expect(await plugin.canExecute(id)).to.equal(false);
+      });
+
       it('does not execute if participation is high enough but support is too low', async () => {
         const {
           alice,
@@ -2660,7 +2749,52 @@ describe('TokenVoting', function () {
         expect(await plugin.canExecute(id)).to.equal(false);
       });
 
-      it('executes after the duration if participation and support are met', async () => {
+      it('does not execute if participation and minimal approval are high enough but support is too low', async () => {
+        const {
+          alice,
+          bob,
+          carol,
+          dave,
+          eve,
+          frank,
+          grace,
+          initializedPlugin: plugin,
+          dummyMetadata,
+          dummyActions,
+        } = await loadFixture(localFixture);
+        const endDate = (await time.latest()) + TIME.DAY;
+
+        await plugin.createProposal(
+          dummyMetadata,
+          dummyActions,
+          0,
+          0,
+          endDate,
+          VoteOption.None,
+          false
+        );
+        const id = 0;
+
+        await voteWithSigners(plugin, id, {
+          yes: [alice, dave, eve], // 30 votes
+          no: [bob, carol, frank, grace], //  40 votes
+          abstain: [], // 0 votes
+        });
+
+        expect(await plugin.isMinParticipationReached(id)).to.be.true;
+        expect(await plugin.isMinApprovalReached(id)).to.be.true;
+        expect(await plugin.isSupportThresholdReachedEarly(id)).to.be.false;
+        expect(await plugin.canExecute(id)).to.equal(false);
+
+        await time.increaseTo(endDate);
+
+        expect(await plugin.isMinParticipationReached(id)).to.be.true;
+        expect(await plugin.isMinApprovalReached(id)).to.be.true;
+        expect(await plugin.isSupportThresholdReached(id)).to.be.false;
+        expect(await plugin.canExecute(id)).to.equal(false);
+      });
+
+      it('executes after the duration if participation, support and minimal approval are met', async () => {
         const {
           alice,
           bob,
@@ -2689,6 +2823,8 @@ describe('TokenVoting', function () {
         });
 
         expect(await plugin.isMinParticipationReached(id)).to.be.true;
+        expect(await plugin.isMinApprovalReached(id)).to.be.true;
+        expect(await plugin.isSupportThresholdReached(id)).to.be.true;
         expect(await plugin.isSupportThresholdReachedEarly(id)).to.be.false;
         expect(await plugin.canExecute(id)).to.equal(false);
 
@@ -2696,10 +2832,11 @@ describe('TokenVoting', function () {
 
         expect(await plugin.isMinParticipationReached(id)).to.be.true;
         expect(await plugin.isSupportThresholdReached(id)).to.be.true;
+        expect(await plugin.isMinApprovalReached(id)).to.be.true;
         expect(await plugin.canExecute(id)).to.equal(true);
       });
 
-      it('executes early if participation and support are met and the vote outcome cannot change anymore', async () => {
+      it('executes early if participation, support and minimal approval are met and the vote outcome cannot change anymore', async () => {
         const {
           alice,
           bob,

--- a/packages/contracts/test/10_unit-testing/11_plugin.ts
+++ b/packages/contracts/test/10_unit-testing/11_plugin.ts
@@ -128,11 +128,11 @@ async function globalFixture(): Promise<GlobalFixtureResult> {
   // todo set a different value
   const defaultMinApproval = pctToRatio(10);
 
-  const pluginInitdata = pluginImplementation.interface.encodeFunctionData(
+  const pluginInitData = pluginImplementation.interface.encodeFunctionData(
     'initialize(address,(uint8,uint32,uint32,uint64,uint256),address,uint32)',
     [dao.address, defaultVotingSettings, token.address, defaultMinApproval]
   );
-  const deploymentTx1 = await proxyFactory.deployUUPSProxy(pluginInitdata);
+  const deploymentTx1 = await proxyFactory.deployUUPSProxy(pluginInitData);
   const proxyCreatedEvent1 = findEvent<ProxyCreatedEvent>(
     await deploymentTx1.wait(),
     proxyFactory.interface.getEvent('ProxyCreated').name
@@ -2141,7 +2141,7 @@ describe('TokenVoting', function () {
 
         // Vote `Yes` with Frank with `tryEarlyExecution` being turned off. The vote is decided now.
         await plugin.connect(frank).vote(id, VoteOption.Yes, false);
-        // Check that the proposal can be excuted but didn't execute yet.
+        // Check that the proposal can be executed but didn't execute yet.
         expect((await plugin.getProposal(id)).executed).to.equal(false);
         expect(await plugin.canExecute(id)).to.equal(true);
 
@@ -2484,19 +2484,19 @@ describe('TokenVoting', function () {
 
         // Vote `Yes` with Eve with `tryEarlyExecution` being turned on. The vote is not decided yet.
         await plugin.connect(eve).vote(id, VoteOption.Yes, true);
-        // Check that the proposal cannot be excuted.
+        // Check that the proposal cannot be executed.
         expect((await plugin.getProposal(id)).executed).to.equal(false);
         expect(await plugin.canExecute(id)).to.equal(false);
 
         // Vote `Yes` with Frank with `tryEarlyExecution` being turned off. The vote is decided now.
         await plugin.connect(frank).vote(id, VoteOption.Yes, false);
-        // Check that the proposal cannot be excuted.
+        // Check that the proposal cannot be executed.
         expect((await plugin.getProposal(id)).executed).to.equal(false);
         expect(await plugin.canExecute(id)).to.equal(false);
 
         // Vote `Yes` with Eve with `tryEarlyExecution` being turned on. The vote is not decided yet.
         await plugin.connect(grace).vote(id, VoteOption.Yes, true);
-        // Check that the proposal cannot be excuted.
+        // Check that the proposal cannot be executed.
         expect((await plugin.getProposal(id)).executed).to.equal(false);
         expect(await plugin.canExecute(id)).to.equal(false);
       });
@@ -3162,7 +3162,7 @@ describe('TokenVoting', function () {
           // Vote `yes` with Carol who has close to 0.0001% of the total supply (only 1 vote is missing that Bob has).
           await plugin.connect(carol).vote(id, VoteOption.Yes, false);
 
-          // Check that only 1 vote is missing to meet 100% particpiation.
+          // Check that only 1 vote is missing to meet 100% participation.
           const proposal = await plugin.getProposal(id);
           const tally = proposal.tally;
           const totalVotingPower = await plugin.totalVotingPower(
@@ -3306,7 +3306,7 @@ describe('TokenVoting', function () {
           await plugin.connect(alice).vote(id, VoteOption.Yes, false);
           expect(await plugin.isMinParticipationReached(id)).to.be.false;
 
-          // 1 vote is still missing to meet particpiation = 100%
+          // 1 vote is still missing to meet participation = 100%
           const proposal = await plugin.getProposal(id);
           const tally = proposal.tally;
           const totalVotingPower = await plugin.totalVotingPower(

--- a/packages/contracts/test/10_unit-testing/11_plugin.ts
+++ b/packages/contracts/test/10_unit-testing/11_plugin.ts
@@ -2632,7 +2632,7 @@ describe('TokenVoting', function () {
 
         await initializedPlugin
           .connect(deployer)
-          .updateMinApproval(newMinApproval);
+          .updateMinApprovals(newMinApproval);
 
         return {
           deployer,
@@ -2952,7 +2952,7 @@ describe('TokenVoting', function () {
 
         await initializedPlugin
           .connect(deployer)
-          .updateMinApproval(minApproval);
+          .updateMinApprovals(minApproval);
 
         return {
           deployer,
@@ -3091,7 +3091,7 @@ describe('TokenVoting', function () {
 
           await initializedPlugin
             .connect(deployer)
-            .updateMinApproval(minApproval);
+            .updateMinApprovals(minApproval);
 
           return {
             deployer,

--- a/packages/contracts/test/10_unit-testing/11_plugin.ts
+++ b/packages/contracts/test/10_unit-testing/11_plugin.ts
@@ -339,7 +339,6 @@ describe('TokenVoting', function () {
 
     it('supports the `IMajorityVoting` OLD interface', async () => {
       const {initializedPlugin: plugin} = await loadFixture(globalFixture);
-      // const iface = IMajorityVoting__factory.createInterface();
       const oldIface = IMajorityVoting_V1_3_0__factory.createInterface();
       expect(await plugin.supportsInterface(getInterfaceId(oldIface))).to.be
         .true;

--- a/packages/contracts/test/10_unit-testing/11_plugin.ts
+++ b/packages/contracts/test/10_unit-testing/11_plugin.ts
@@ -127,7 +127,6 @@ async function globalFixture(): Promise<GlobalFixtureResult> {
     minProposerVotingPower: 0,
   };
 
-  // todo set a different value
   const defaultMinApproval = pctToRatio(10);
 
   const pluginInitData = pluginImplementation.interface.encodeFunctionData(

--- a/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
+++ b/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
@@ -28,6 +28,7 @@ import {getNamedTypesFromMetadata} from '@aragon/osx-commons-sdk';
 import {TIME} from '@aragon/osx-commons-sdk';
 import {pctToRatio} from '@aragon/osx-commons-sdk';
 import {DAO} from '@aragon/osx-ethers';
+import {BigNumber} from '@ethersproject/bignumber';
 import {loadFixture} from '@nomicfoundation/hardhat-network-helpers';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
 import {expect} from 'chai';
@@ -49,8 +50,10 @@ type FixtureResult = {
     symbol: string;
   };
   defaultMintSettings: GovernanceERC20.MintSettingsStruct;
+  defaultMinApproval: BigNumber;
   prepareInstallationInputs: string;
   prepareUninstallationInputs: string;
+  prepareUpdateBuild3Inputs: string;
   dao: DAO;
   governanceERC20Base: GovernanceERC20;
   governanceWrappedERC20Base: GovernanceWrappedERC20;
@@ -70,6 +73,8 @@ async function fixture(): Promise<FixtureResult> {
     symbol: 'SYMB',
   };
   const defaultMintSettings = {receivers: [], amounts: []};
+  // todo set a different value
+  const defaultMinApproval = BigNumber.from(0);
 
   const erc20 = await new ERC20__factory(deployer).deploy('erc20', 'ERC20');
 
@@ -106,6 +111,7 @@ async function fixture(): Promise<FixtureResult> {
       Object.values(defaultVotingSettings),
       Object.values(defaultTokenSettings),
       Object.values(defaultMintSettings),
+      defaultMinApproval,
     ]
   );
 
@@ -117,6 +123,14 @@ async function fixture(): Promise<FixtureResult> {
     []
   );
 
+  // Provide update inputs
+  const prepareUpdateBuild3Inputs = ethers.utils.defaultAbiCoder.encode(
+    getNamedTypesFromMetadata(
+      METADATA.build.pluginSetup.prepareUpdate[3].inputs
+    ),
+    [defaultMinApproval]
+  );
+
   return {
     deployer,
     alice,
@@ -126,8 +140,10 @@ async function fixture(): Promise<FixtureResult> {
     defaultVotingSettings,
     defaultTokenSettings,
     defaultMintSettings,
+    defaultMinApproval,
     prepareInstallationInputs,
     prepareUninstallationInputs,
+    prepareUpdateBuild3Inputs,
     dao,
     governanceERC20Base,
     governanceWrappedERC20Base,
@@ -184,6 +200,7 @@ describe('TokenVotingSetup', function () {
         dao,
         defaultVotingSettings,
         defaultTokenSettings,
+        defaultMinApproval,
       } = await loadFixture(fixture);
 
       const receivers: string[] = [AddressZero];
@@ -196,6 +213,7 @@ describe('TokenVotingSetup', function () {
           Object.values(defaultVotingSettings),
           Object.values(defaultTokenSettings),
           {receivers, amounts},
+          defaultMinApproval,
         ]
       );
 
@@ -226,6 +244,7 @@ describe('TokenVotingSetup', function () {
         dao,
         defaultVotingSettings,
         defaultMintSettings,
+        defaultMinApproval,
       } = await loadFixture(fixture);
 
       const data = abiCoder.encode(
@@ -236,6 +255,7 @@ describe('TokenVotingSetup', function () {
           Object.values(defaultVotingSettings),
           [alice.address, '', ''], // Instead of a token address, we pass Alice's address here.
           Object.values(defaultMintSettings),
+          defaultMinApproval,
         ]
       );
 
@@ -245,8 +265,13 @@ describe('TokenVotingSetup', function () {
     });
 
     it('fails if passed token address is not ERC20', async () => {
-      const {pluginSetup, dao, defaultVotingSettings, defaultMintSettings} =
-        await loadFixture(fixture);
+      const {
+        pluginSetup,
+        dao,
+        defaultVotingSettings,
+        defaultMintSettings,
+        defaultMinApproval,
+      } = await loadFixture(fixture);
 
       const data = abiCoder.encode(
         getNamedTypesFromMetadata(
@@ -256,6 +281,7 @@ describe('TokenVotingSetup', function () {
           Object.values(defaultVotingSettings),
           [dao.address, '', ''],
           Object.values(defaultMintSettings),
+          defaultMinApproval,
         ]
       );
 
@@ -272,6 +298,7 @@ describe('TokenVotingSetup', function () {
         defaultTokenSettings,
         defaultMintSettings,
         erc20,
+        defaultMinApproval,
       } = await loadFixture(fixture);
 
       const nonce = await ethers.provider.getTransactionCount(
@@ -299,6 +326,7 @@ describe('TokenVotingSetup', function () {
             defaultTokenSettings.symbol,
           ],
           Object.values(defaultMintSettings),
+          defaultMinApproval,
         ]
       );
 
@@ -337,6 +365,7 @@ describe('TokenVotingSetup', function () {
         defaultVotingSettings,
         defaultMintSettings,
         erc20,
+        defaultMinApproval,
       } = await loadFixture(fixture);
 
       const nonce = await ethers.provider.getTransactionCount(
@@ -355,6 +384,7 @@ describe('TokenVotingSetup', function () {
           Object.values(defaultVotingSettings),
           [erc20.address, 'myName', 'mySymb'],
           Object.values(defaultMintSettings),
+          defaultMinApproval,
         ]
       );
 
@@ -382,6 +412,7 @@ describe('TokenVotingSetup', function () {
         dao,
         defaultVotingSettings,
         defaultMintSettings,
+        defaultMinApproval,
       } = await loadFixture(fixture);
 
       const governanceERC20 = await new GovernanceERC20__factory(
@@ -405,6 +436,7 @@ describe('TokenVotingSetup', function () {
           Object.values(defaultVotingSettings),
           [governanceERC20.address, '', ''],
           Object.values(defaultMintSettings),
+          defaultMinApproval,
         ]
       );
 
@@ -436,13 +468,9 @@ describe('TokenVotingSetup', function () {
     });
 
     it('correctly returns plugin, helpers and permissions, when a token address is not supplied', async () => {
-      const {
-        pluginSetup,
-        dao,
-        defaultVotingSettings,
-        defaultTokenSettings,
-        defaultMintSettings,
-      } = await loadFixture(fixture);
+      const {pluginSetup, dao, prepareInstallationInputs} = await loadFixture(
+        fixture
+      );
 
       const nonce = await ethers.provider.getTransactionCount(
         pluginSetup.address
@@ -457,21 +485,13 @@ describe('TokenVotingSetup', function () {
         nonce: nonce + 1,
       });
 
-      const data = abiCoder.encode(
-        getNamedTypesFromMetadata(
-          METADATA.build.pluginSetup.prepareInstallation.inputs
-        ),
-        [
-          Object.values(defaultVotingSettings),
-          Object.values(defaultTokenSettings),
-          Object.values(defaultMintSettings),
-        ]
-      );
-
       const {
         plugin,
         preparedSetupData: {helpers, permissions},
-      } = await pluginSetup.callStatic.prepareInstallation(dao.address, data);
+      } = await pluginSetup.callStatic.prepareInstallation(
+        dao.address,
+        prepareInstallationInputs
+      );
 
       expect(plugin).to.be.equal(anticipatedPluginAddress);
       expect(helpers.length).to.be.equal(1);
@@ -510,6 +530,7 @@ describe('TokenVotingSetup', function () {
         defaultVotingSettings,
         defaultTokenSettings,
         defaultMintSettings,
+        defaultMinApproval,
       } = await loadFixture(fixture);
 
       const daoAddress = dao.address;
@@ -522,6 +543,7 @@ describe('TokenVotingSetup', function () {
           Object.values(defaultVotingSettings),
           [AddressZero, defaultTokenSettings.name, defaultTokenSettings.symbol],
           Object.values(defaultMintSettings),
+          defaultMinApproval,
         ]
       );
 
@@ -575,7 +597,9 @@ describe('TokenVotingSetup', function () {
 
   describe('prepareUpdate', async () => {
     it('returns the permissions expected for the update from build 1', async () => {
-      const {pluginSetup, dao} = await loadFixture(fixture);
+      const {pluginSetup, dao, prepareUpdateBuild3Inputs} = await loadFixture(
+        fixture
+      );
       const plugin = ethers.Wallet.createRandom().address;
 
       // Make a static call to check that the plugin update data being returned is correct.
@@ -587,12 +611,17 @@ describe('TokenVotingSetup', function () {
           ethers.Wallet.createRandom().address,
           ethers.Wallet.createRandom().address,
         ],
-        data: [],
+        data: prepareUpdateBuild3Inputs,
         plugin,
       });
 
       // Check the return data.
-      expect(initData).to.be.eq('0x');
+      expect(initData).to.be.eq(
+        TokenVoting__factory.createInterface().encodeFunctionData(
+          'initializeFrom',
+          [prepareUpdateBuild3Inputs]
+        )
+      );
       expect(helpers).to.be.eql([]);
       expect(permissions.length).to.be.eql(1);
       expect(permissions).to.deep.equal([
@@ -607,7 +636,9 @@ describe('TokenVotingSetup', function () {
     });
 
     it('returns the permissions expected for the update from build 2', async () => {
-      const {pluginSetup, dao} = await loadFixture(fixture);
+      const {pluginSetup, dao, prepareUpdateBuild3Inputs} = await loadFixture(
+        fixture
+      );
       const plugin = ethers.Wallet.createRandom().address;
 
       // Make a static call to check that the plugin update data being returned is correct.
@@ -619,12 +650,17 @@ describe('TokenVotingSetup', function () {
           ethers.Wallet.createRandom().address,
           ethers.Wallet.createRandom().address,
         ],
-        data: [],
+        data: prepareUpdateBuild3Inputs,
         plugin,
       });
 
       // Check the return data.
-      expect(initData).to.be.eq('0x');
+      expect(initData).to.be.eq(
+        TokenVoting__factory.createInterface().encodeFunctionData(
+          'initializeFrom',
+          [prepareUpdateBuild3Inputs]
+        )
+      );
       expect(helpers).to.be.eql([]);
       expect(permissions.length).to.be.eql(1);
       expect(permissions).to.deep.equal([

--- a/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
+++ b/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
@@ -73,8 +73,6 @@ async function fixture(): Promise<FixtureResult> {
     symbol: 'SYMB',
   };
   const defaultMintSettings = {receivers: [], amounts: []};
-  // todo set a different value
-  const defaultMinApproval = BigNumber.from(0);
 
   const erc20 = await new ERC20__factory(deployer).deploy('erc20', 'ERC20');
 
@@ -101,6 +99,9 @@ async function fixture(): Promise<FixtureResult> {
     minDuration: TIME.HOUR,
     minProposerVotingPower: 0,
   };
+
+  // todo set a different value
+  const defaultMinApproval = pctToRatio(30);
 
   // Provide installation inputs
   const prepareInstallationInputs = ethers.utils.defaultAbiCoder.encode(

--- a/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
+++ b/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
@@ -100,7 +100,6 @@ async function fixture(): Promise<FixtureResult> {
     minProposerVotingPower: 0,
   };
 
-  // todo set a different value
   const defaultMinApproval = pctToRatio(30);
 
   // Provide installation inputs

--- a/packages/contracts/test/10_unit-testing/base/11_majority-voting.ts
+++ b/packages/contracts/test/10_unit-testing/base/11_majority-voting.ts
@@ -204,7 +204,7 @@ describe('MajorityVotingMock', function () {
     });
   });
 
-  describe('updateMinApproval', async () => {
+  describe('updateMinApprovals', async () => {
     beforeEach(async () => {
       await votingBase.initializeMock(dao.address, votingSettings, minApproval);
     });
@@ -212,13 +212,13 @@ describe('MajorityVotingMock', function () {
     it('reverts if the minimum approval specified exceeds 100%', async () => {
       minApproval = pctToRatio(1000);
 
-      await expect(votingBase.updateMinApproval(minApproval))
+      await expect(votingBase.updateMinApprovals(minApproval))
         .to.be.revertedWithCustomError(votingBase, 'RatioOutOfBounds')
         .withArgs(pctToRatio(100), minApproval);
     });
 
     it('should change the minimum approval successfully', async () => {
-      await expect(votingBase.updateMinApproval(minApproval))
+      await expect(votingBase.updateMinApprovals(minApproval))
         .to.emit(votingBase, 'VotingMinApprovalUpdated')
         .withArgs(minApproval);
     });

--- a/packages/contracts/test/10_unit-testing/base/11_majority-voting.ts
+++ b/packages/contracts/test/10_unit-testing/base/11_majority-voting.ts
@@ -12,6 +12,7 @@ import {
 import {ProxyCreatedEvent} from '../../../typechain/@aragon/osx-commons-contracts/src/utils/deployment/ProxyFactory';
 import {MajorityVotingBase} from '../../../typechain/src/MajorityVotingBase';
 import {MAJORITY_VOTING_BASE_INTERFACE} from '../../test-utils/majority-voting-constants';
+import {IMajorityVoting_V1_3_0__factory} from '../../test-utils/typechain-versions';
 import {VotingMode} from '../../test-utils/voting-helpers';
 import {TIME, findEvent} from '@aragon/osx-commons-sdk';
 import {getInterfaceId} from '@aragon/osx-commons-sdk';
@@ -116,10 +117,24 @@ describe('MajorityVotingMock', function () {
         .true;
     });
 
+    it('supports the `IMajorityVoting` OLD interface', async () => {
+      const oldIface = IMajorityVoting_V1_3_0__factory.createInterface();
+      expect(await votingBase.supportsInterface(getInterfaceId(oldIface))).to.be
+        .true;
+    });
+
     it('supports the `MajorityVotingBase` interface', async () => {
       expect(
         await votingBase.supportsInterface(
           getInterfaceId(MAJORITY_VOTING_BASE_INTERFACE)
+        )
+      ).to.be.true;
+    });
+
+    it('supports the `MajorityVotingBase` OLD interface', async () => {
+      expect(
+        await votingBase.supportsInterface(
+          getInterfaceId(MAJORITY_VOTING_BASE_OLD_INTERFACE)
         )
       ).to.be.true;
     });

--- a/packages/contracts/test/10_unit-testing/base/11_majority-voting.ts
+++ b/packages/contracts/test/10_unit-testing/base/11_majority-voting.ts
@@ -19,6 +19,7 @@ import {pctToRatio} from '@aragon/osx-commons-sdk';
 import {DAO} from '@aragon/osx-ethers';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
 import {expect} from 'chai';
+import {BigNumber} from 'ethers';
 import {ethers} from 'hardhat';
 
 describe('MajorityVotingMock', function () {
@@ -28,6 +29,7 @@ describe('MajorityVotingMock', function () {
   let dao: DAO;
 
   let votingSettings: MajorityVotingBase.VotingSettingsStruct;
+  let minApproval: BigNumber;
 
   before(async () => {
     signers = await ethers.getSigners();
@@ -44,6 +46,7 @@ describe('MajorityVotingMock', function () {
       minDuration: TIME.HOUR,
       minProposerVotingPower: 0,
     };
+    minApproval = pctToRatio(10);
 
     const pluginImplementation = await new MajorityVotingMock__factory(
       signers[0]
@@ -70,10 +73,10 @@ describe('MajorityVotingMock', function () {
 
   describe('initialize', async () => {
     it('reverts if trying to re-initialize', async () => {
-      await votingBase.initializeMock(dao.address, votingSettings);
+      await votingBase.initializeMock(dao.address, votingSettings, minApproval);
 
       await expect(
-        votingBase.initializeMock(dao.address, votingSettings)
+        votingBase.initializeMock(dao.address, votingSettings, minApproval)
       ).to.be.revertedWith('Initializable: contract is already initialized');
     });
   });
@@ -124,7 +127,7 @@ describe('MajorityVotingMock', function () {
 
   describe('updateVotingSettings', async () => {
     beforeEach(async () => {
-      await votingBase.initializeMock(dao.address, votingSettings);
+      await votingBase.initializeMock(dao.address, votingSettings, minApproval);
     });
 
     it('reverts if the support threshold specified equals 100%', async () => {
@@ -180,6 +183,26 @@ describe('MajorityVotingMock', function () {
           votingSettings.minDuration,
           votingSettings.minProposerVotingPower
         );
+    });
+  });
+
+  describe('updateMinApproval', async () => {
+    beforeEach(async () => {
+      await votingBase.initializeMock(dao.address, votingSettings, minApproval);
+    });
+
+    it('reverts if the minimum approval specified exceeds 100%', async () => {
+      minApproval = pctToRatio(1000);
+
+      await expect(votingBase.updateMinApproval(minApproval))
+        .to.be.revertedWithCustomError(votingBase, 'RatioOutOfBounds')
+        .withArgs(pctToRatio(100), minApproval);
+    });
+
+    it('should change the minimum approval successfully', async () => {
+      await expect(votingBase.updateMinApproval(minApproval))
+        .to.emit(votingBase, 'VotingMinApprovalUpdated')
+        .withArgs(minApproval);
     });
   });
 });

--- a/packages/contracts/test/10_unit-testing/base/11_majority-voting.ts
+++ b/packages/contracts/test/10_unit-testing/base/11_majority-voting.ts
@@ -11,7 +11,10 @@ import {
 } from '../../../typechain';
 import {ProxyCreatedEvent} from '../../../typechain/@aragon/osx-commons-contracts/src/utils/deployment/ProxyFactory';
 import {MajorityVotingBase} from '../../../typechain/src/MajorityVotingBase';
-import {MAJORITY_VOTING_BASE_INTERFACE} from '../../test-utils/majority-voting-constants';
+import {
+  MAJORITY_VOTING_BASE_INTERFACE,
+  MAJORITY_VOTING_BASE_OLD_INTERFACE,
+} from '../../test-utils/majority-voting-constants';
 import {IMajorityVoting_V1_3_0__factory} from '../../test-utils/typechain-versions';
 import {VotingMode} from '../../test-utils/voting-helpers';
 import {TIME, findEvent} from '@aragon/osx-commons-sdk';

--- a/packages/contracts/test/20_integration-testing/22_setup-processing.ts
+++ b/packages/contracts/test/20_integration-testing/22_setup-processing.ts
@@ -128,6 +128,9 @@ async function fixture(): Promise<FixtureResult> {
     minProposerVotingPower: 0,
   };
 
+  // todo set a different value
+  const defaultMinApproval = pctToRatio(30);
+
   const defaultTokenSettings = {
     addr: token.address,
     name: '', // only relevant if `address(0)` is provided as the token address
@@ -138,9 +141,6 @@ async function fixture(): Promise<FixtureResult> {
     receivers: [],
     amounts: [],
   };
-
-  // todo set a different value
-  const defaultMinApproval = BigNumber.from(0);
 
   // Provide uninstallation inputs
   const prepareInstallationInputs = ethers.utils.defaultAbiCoder.encode(

--- a/packages/contracts/test/20_integration-testing/22_setup-processing.ts
+++ b/packages/contracts/test/20_integration-testing/22_setup-processing.ts
@@ -128,7 +128,6 @@ async function fixture(): Promise<FixtureResult> {
     minProposerVotingPower: 0,
   };
 
-  // todo set a different value
   const defaultMinApproval = pctToRatio(30);
 
   const defaultTokenSettings = {

--- a/packages/contracts/test/20_integration-testing/22_setup-processing.ts
+++ b/packages/contracts/test/20_integration-testing/22_setup-processing.ts
@@ -34,6 +34,7 @@ import {
   DAO,
   TokenVoting__factory,
 } from '@aragon/osx-ethers';
+import {BigNumber} from '@ethersproject/bignumber';
 import {loadFixture} from '@nomicfoundation/hardhat-network-helpers';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
 import {expect} from 'chai';
@@ -57,6 +58,10 @@ type FixtureResult = {
     symbol: string;
   };
   defaultMintSettings: GovernanceERC20.MintSettingsStruct;
+  defaultMinApproval: BigNumber;
+  prepareInstallationInputs: string;
+  prepareInstallData: any;
+  prepareUpdateData: any;
 };
 
 async function fixture(): Promise<FixtureResult> {
@@ -134,6 +139,32 @@ async function fixture(): Promise<FixtureResult> {
     amounts: [],
   };
 
+  // todo set a different value
+  const defaultMinApproval = BigNumber.from(0);
+
+  // Provide uninstallation inputs
+  const prepareInstallationInputs = ethers.utils.defaultAbiCoder.encode(
+    getNamedTypesFromMetadata(
+      METADATA.build.pluginSetup.prepareInstallation.inputs
+    ),
+    [
+      Object.values(defaultVotingSettings),
+      Object.values(defaultTokenSettings),
+      Object.values(defaultMintSettings),
+      defaultMinApproval,
+    ]
+  );
+
+  const prepareInstallData = {
+    votingSettings: Object.values(defaultVotingSettings),
+    tokenSettings: Object.values(defaultTokenSettings),
+    mintSettings: Object.values(defaultMintSettings),
+    defaultMinApproval,
+  };
+
+  const prepareUpdateData = [defaultMinApproval];
+  // Provide update inputs
+  // const prepareUpdateBuild3Data = [defaultMinApproval];
   return {
     deployer,
     alice,
@@ -146,6 +177,10 @@ async function fixture(): Promise<FixtureResult> {
     defaultVotingSettings,
     defaultTokenSettings,
     defaultMintSettings,
+    defaultMinApproval,
+    prepareInstallationInputs,
+    prepareInstallData,
+    prepareUpdateData,
   };
 }
 
@@ -157,9 +192,7 @@ describe(`PluginSetup processing on network '${productionNetworkName}'`, functio
       psp,
       dao,
       pluginSetupRefLatestBuild,
-      defaultVotingSettings,
-      defaultTokenSettings,
-      defaultMintSettings,
+      prepareInstallationInputs,
     } = await loadFixture(fixture);
 
     // Grant deployer all required permissions
@@ -181,25 +214,12 @@ describe(`PluginSetup processing on network '${productionNetworkName}'`, functio
       .connect(deployer)
       .grant(dao.address, psp.address, DAO_PERMISSIONS.ROOT_PERMISSION_ID);
 
-    const prepareInstallData = {
-      votingSettings: Object.values(defaultVotingSettings),
-      tokenSettings: Object.values(defaultTokenSettings),
-      mintSettings: Object.values(defaultMintSettings),
-    };
-
-    const prepareInstallInputType = getNamedTypesFromMetadata(
-      METADATA.build.pluginSetup.prepareInstallation.inputs
-    );
-
     const results = await installPLugin(
       deployer,
       psp,
       dao,
       pluginSetupRefLatestBuild,
-      ethers.utils.defaultAbiCoder.encode(
-        prepareInstallInputType,
-        Object.values(prepareInstallData)
-      )
+      prepareInstallationInputs
     );
 
     const plugin = TokenVoting__factory.connect(
@@ -239,6 +259,7 @@ describe(`PluginSetup processing on network '${productionNetworkName}'`, functio
       dao,
       defaultVotingSettings,
       pluginSetupRefLatestBuild,
+      defaultMinApproval,
     } = await loadFixture(fixture);
 
     // Grant deployer all required permissions
@@ -264,6 +285,7 @@ describe(`PluginSetup processing on network '${productionNetworkName}'`, functio
       votingSettings: Object.values(defaultVotingSettings),
       tokenSettings: [ethers.constants.AddressZero, 'testToken', 'TEST'],
       mintSettings: [[alice.address], ['1000']],
+      defaultMinApproval,
     };
 
     const prepareInstallInputType = getNamedTypesFromMetadata(
@@ -315,18 +337,11 @@ describe(`PluginSetup processing on network '${productionNetworkName}'`, functio
       deployer,
       psp,
       dao,
-      defaultVotingSettings,
-      defaultTokenSettings,
-      defaultMintSettings,
       pluginRepo,
       pluginSetupRefLatestBuild,
+      prepareInstallData,
+      prepareUpdateData,
     } = await loadFixture(fixture);
-
-    const prepareInstallData = {
-      votingSettings: Object.values(defaultVotingSettings),
-      tokenSettings: Object.values(defaultTokenSettings),
-      mintSettings: Object.values(defaultMintSettings),
-    };
 
     await updateFromBuildTest(
       dao,
@@ -336,7 +351,7 @@ describe(`PluginSetup processing on network '${productionNetworkName}'`, functio
       pluginSetupRefLatestBuild,
       1,
       Object.values(prepareInstallData),
-      []
+      prepareUpdateData
     );
   });
 
@@ -347,16 +362,10 @@ describe(`PluginSetup processing on network '${productionNetworkName}'`, functio
       dao,
       pluginRepo,
       pluginSetupRefLatestBuild,
-      defaultVotingSettings,
-      defaultTokenSettings,
-      defaultMintSettings,
-    } = await loadFixture(fixture);
 
-    const prepareInstallData = {
-      votingSettings: Object.values(defaultVotingSettings),
-      tokenSettings: Object.values(defaultTokenSettings),
-      mintSettings: Object.values(defaultMintSettings),
-    };
+      prepareInstallData,
+      prepareUpdateData,
+    } = await loadFixture(fixture);
 
     await updateFromBuildTest(
       dao,
@@ -366,7 +375,7 @@ describe(`PluginSetup processing on network '${productionNetworkName}'`, functio
       pluginSetupRefLatestBuild,
       2,
       Object.values(prepareInstallData),
-      []
+      prepareUpdateData
     );
   });
 });

--- a/packages/contracts/test/20_integration-testing/test-helpers.ts
+++ b/packages/contracts/test/20_integration-testing/test-helpers.ts
@@ -27,6 +27,8 @@ import {expect} from 'chai';
 import {ContractTransaction} from 'ethers';
 import {ethers} from 'hardhat';
 
+const latestBuild = 3;
+
 export async function installPLugin(
   signer: SignerWithAddress,
   psp: PluginSetupProcessor,
@@ -324,7 +326,7 @@ export async function updateFromBuildTest(
       pluginSetupRefLatestBuild,
       ethers.utils.defaultAbiCoder.encode(
         getNamedTypesFromMetadata(
-          METADATA.build.pluginSetup.prepareUpdate[1].inputs
+          METADATA.build.pluginSetup.prepareUpdate[latestBuild].inputs
         ),
         updateInputs
       )

--- a/packages/contracts/test/30_regression-testing/31_upgradeability.ts
+++ b/packages/contracts/test/30_regression-testing/31_upgradeability.ts
@@ -1,6 +1,7 @@
 import {createDaoProxy} from '../20_integration-testing/test-helpers';
 import {TestGovernanceERC20} from '../../typechain';
 import {MajorityVotingBase} from '../../typechain/src';
+import {INITIALIZE_SIGNATURE} from '../test-utils/token-voting-constants';
 import {
   TokenVoting_V1_0_0__factory,
   TokenVoting_V1_3_0__factory,
@@ -38,7 +39,7 @@ describe('Upgrades', () => {
         defaultInitData.token.address,
         defaultInitData.minApproval,
       ],
-      'initialize(address,(uint8,uint32,uint32,uint64,uint256),address,uint32)',
+      INITIALIZE_SIGNATURE,
       currentContractFactory,
       PLUGIN_UUPS_UPGRADEABLE_PERMISSIONS.UPGRADE_PLUGIN_PERMISSION_ID,
       dao

--- a/packages/contracts/test/30_regression-testing/31_upgradeability.ts
+++ b/packages/contracts/test/30_regression-testing/31_upgradeability.ts
@@ -36,7 +36,7 @@ describe('Upgrades', () => {
         defaultInitData.votingSettings,
         defaultInitData.token.address,
       ],
-      'initialize',
+      'initialize(address,(uint8,uint32,uint32,uint64,uint256),address)',
       currentContractFactory,
       PLUGIN_UUPS_UPGRADEABLE_PERMISSIONS.UPGRADE_PLUGIN_PERMISSION_ID,
       dao

--- a/packages/contracts/test/30_regression-testing/31_upgradeability.ts
+++ b/packages/contracts/test/30_regression-testing/31_upgradeability.ts
@@ -21,6 +21,7 @@ import {DAO, TestGovernanceERC20__factory} from '@aragon/osx-ethers';
 import {loadFixture} from '@nomicfoundation/hardhat-network-helpers';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
 import {expect} from 'chai';
+import {BigNumber} from 'ethers';
 import {ethers} from 'hardhat';
 
 describe('Upgrades', () => {
@@ -35,8 +36,9 @@ describe('Upgrades', () => {
         dao.address,
         defaultInitData.votingSettings,
         defaultInitData.token.address,
+        defaultInitData.minApproval,
       ],
-      'initialize(address,(uint8,uint32,uint32,uint64,uint256),address)',
+      'initialize(address,(uint8,uint32,uint32,uint64,uint256),address,uint32)',
       currentContractFactory,
       PLUGIN_UUPS_UPGRADEABLE_PERMISSIONS.UPGRADE_PLUGIN_PERMISSION_ID,
       dao
@@ -124,6 +126,7 @@ type FixtureResult = {
   defaultInitData: {
     votingSettings: MajorityVotingBase.VotingSettingsStruct;
     token: TestGovernanceERC20;
+    minApproval: BigNumber;
   };
 };
 
@@ -156,6 +159,7 @@ async function fixture(): Promise<FixtureResult> {
   const defaultInitData = {
     votingSettings,
     token: token,
+    minApproval: pctToRatio(10),
   };
 
   return {

--- a/packages/contracts/test/test-utils/majority-voting-constants.ts
+++ b/packages/contracts/test/test-utils/majority-voting-constants.ts
@@ -7,6 +7,17 @@ export const MAJORITY_VOTING_BASE_INTERFACE = new ethers.utils.Interface([
   'function totalVotingPower(uint256)',
   'function getProposal(uint256)',
   'function updateVotingSettings(tuple(uint8,uint32,uint32,uint64,uint256))',
+  'function updateMinApproval(uint32)',
+  'function createProposal(bytes,tuple(address,uint256,bytes)[],uint256,uint64,uint64,uint8,bool)',
+]);
+
+export const MAJORITY_VOTING_BASE_OLD_INTERFACE = new ethers.utils.Interface([
+  'function minDuration()',
+  'function minProposerVotingPower()',
+  'function votingMode()',
+  'function totalVotingPower(uint256)',
+  'function getProposal(uint256)',
+  'function updateVotingSettings(tuple(uint8,uint32,uint32,uint64,uint256))',
   'function createProposal(bytes,tuple(address,uint256,bytes)[],uint256,uint64,uint64,uint8,bool)',
 ]);
 

--- a/packages/contracts/test/test-utils/majority-voting-constants.ts
+++ b/packages/contracts/test/test-utils/majority-voting-constants.ts
@@ -7,7 +7,7 @@ export const MAJORITY_VOTING_BASE_INTERFACE = new ethers.utils.Interface([
   'function totalVotingPower(uint256)',
   'function getProposal(uint256)',
   'function updateVotingSettings(tuple(uint8,uint32,uint32,uint64,uint256))',
-  'function updateMinApprovals(uint32)',
+  'function updateMinApprovals(uint256)',
   'function createProposal(bytes,tuple(address,uint256,bytes)[],uint256,uint64,uint64,uint8,bool)',
 ]);
 

--- a/packages/contracts/test/test-utils/majority-voting-constants.ts
+++ b/packages/contracts/test/test-utils/majority-voting-constants.ts
@@ -7,7 +7,7 @@ export const MAJORITY_VOTING_BASE_INTERFACE = new ethers.utils.Interface([
   'function totalVotingPower(uint256)',
   'function getProposal(uint256)',
   'function updateVotingSettings(tuple(uint8,uint32,uint32,uint64,uint256))',
-  'function updateMinApproval(uint32)',
+  'function updateMinApprovals(uint32)',
   'function createProposal(bytes,tuple(address,uint256,bytes)[],uint256,uint64,uint64,uint8,bool)',
 ]);
 

--- a/packages/contracts/test/test-utils/token-voting-constants.ts
+++ b/packages/contracts/test/test-utils/token-voting-constants.ts
@@ -29,4 +29,4 @@ export const VOTING_EVENTS = {
 export const INITIALIZE_SIGNATURE_OLD =
   'initialize(address,(uint8,uint32,uint32,uint64,uint256),address)';
 export const INITIALIZE_SIGNATURE =
-  'initialize(address,(uint8,uint32,uint32,uint64,uint256),address,uint32)';
+  'initialize(address,(uint8,uint32,uint32,uint64,uint256),address,uint256)';

--- a/packages/contracts/test/test-utils/token-voting-constants.ts
+++ b/packages/contracts/test/test-utils/token-voting-constants.ts
@@ -25,3 +25,8 @@ export const VOTING_EVENTS = {
   VOTING_SETTINGS_UPDATED: 'VotingSettingsUpdated',
   VOTE_CAST: 'VoteCast',
 };
+
+export const INITIALIZE_SIGNATURE_OLD =
+  'initialize(address,(uint8,uint32,uint32,uint64,uint256),address)';
+export const INITIALIZE_SIGNATURE =
+  'initialize(address,(uint8,uint32,uint32,uint64,uint256),address,uint32)';

--- a/packages/contracts/test/test-utils/typechain-versions.ts
+++ b/packages/contracts/test/test-utils/typechain-versions.ts
@@ -23,3 +23,7 @@ export {GovernanceWrappedERC20__factory as GovernanceWrappedERC20_V1_0_0__factor
 export {GovernanceWrappedERC20__factory as GovernanceWrappedERC20_V1_3_0__factory} from '../../typechain/factories/@aragon/osx-v1.3.0/token/ERC20/governance/GovernanceWrappedERC20__factory';
 export {GovernanceWrappedERC20__factory} from '../../typechain/factories/src/ERC20/governance/GovernanceWrappedERC20__factory';
 export {GovernanceWrappedERC20} from '../../typechain/src/ERC20/governance/GovernanceWrappedERC20';
+
+/* Majority Voting Base */
+export {IMajorityVoting__factory as IMajorityVoting_V1_3_0__factory} from '../../typechain/factories/@aragon/osx-v1.0.0/plugins/governance/majority-voting/IMajorityVoting__factory';
+export {MajorityVotingBase__factory} from '../../typechain/factories/src/MajorityVotingBase__factory';


### PR DESCRIPTION
Task ID: [OD-1451](https://aragonassociation.atlassian.net/browse/OS-1451)

TBD:
- The new `updateMinApproval` permission id should be `UPDATE_VOTING_SETTINGS_PERMISSION_ID` or a new one should be created? 
- Old `initialize` function on Token voting should revert or continue allowing initialize the plugin without `minApproval` value? 