### PR TITLE
Timepoints, minting freeze, supply exclusion

### DIFF
--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -22,6 +22,7 @@ import type {NetworkUserConfig} from 'hardhat/types';
 import {resolve} from 'path';
 import 'solidity-coverage';
 import 'solidity-docgen';
+import 'hardhat-tracer';
 
 const dotenvConfigPath: string = process.env.DOTENV_CONFIG_PATH || '../../.env';
 dotenvConfig({path: resolve(__dirname, dotenvConfigPath), override: true});

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -69,6 +69,7 @@
     "hardhat": "^2.22.15",
     "hardhat-deploy": "0.12.4",
     "hardhat-gas-reporter": "^1.0.9",
+    "hardhat-tracer": "^3.2.0",
     "ipfs-http-client": "^51.0.0",
     "lodash.startcase": "^4.4.0",
     "mocha": "^10.1.0",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "1.3",
+  "version": "1.4.0",
   "author": "Aragon X",
   "repository": {
     "type": "git",
@@ -39,6 +39,7 @@
     "@aragon/osx-ethers": "^1.4.0",
     "@aragon/osx-v1.0.0": "npm:@aragon/osx@1.0.1",
     "@aragon/osx-v1.3.0": "npm:@aragon/osx@1.3.0",
+    "@aragon/token-voting-plugin-r1-b3": "https://gitpkg.now.sh/aragon/token-voting-plugin/packages/contracts?commit=release-v1.3",
     "@ethersproject/abi": "5.7.0",
     "@ethersproject/abstract-signer": "5.7.0",
     "@ethersproject/bignumber": "5.7.0",

--- a/packages/contracts/plugin-settings.ts
+++ b/packages/contracts/plugin-settings.ts
@@ -39,15 +39,19 @@ export const emptyMintSettings: GovernanceERC20.MintSettingsStruct = {
   amounts: [],
 };
 
+export const emptyExcludedAccounts: string[] = [];
+
 export const GOVERNANCE_ERC20_DEPLOY_ARGS = [
   zeroDaoAddress,
   emptyName,
   emptySymbol,
   emptyMintSettings,
+  emptyExcludedAccounts,
 ];
 
 export const GOVERNANCE_WRAPPED_ERC20_DEPLOY_ARGS = [
   zeroTokenAddress,
   emptyName,
   emptySymbol,
+  emptyExcludedAccounts,
 ];

--- a/packages/contracts/plugin-settings.ts
+++ b/packages/contracts/plugin-settings.ts
@@ -18,7 +18,7 @@ export const VOTING_POWER_CONDITION_CONTRACT_NAME = 'VotingPowerCondition';
 
 export const VERSION: VersionTag = {
   release: 1, // Increment this number ONLY if breaking/incompatible changes were made. Updates between releases are NOT possible.
-  build: 3, // Increment this number if non-breaking/compatible changes were made. Updates to newer builds are possible.
+  build: 4, // Increment this number if non-breaking/compatible changes were made. Updates to newer builds are possible.
 };
 
 // The metadata associated with the plugin version you are currently working on.

--- a/packages/contracts/plugin-settings.ts
+++ b/packages/contracts/plugin-settings.ts
@@ -19,7 +19,7 @@ export const VOTING_POWER_CONDITION_CONTRACT_NAME = 'VotingPowerCondition';
 export const VERSION: VersionTag = {
   release: 1, // Increment this number ONLY if breaking/incompatible changes were made. Updates between releases are NOT possible.
   build: 4, // Increment this number if non-breaking/compatible changes were made. Updates to newer builds are possible.
-};
+} as const;
 
 // The metadata associated with the plugin version you are currently working on.
 // For more details, visit https://devs.aragon.org/docs/osx/how-to-guides/plugin-development/publication/metadata.
@@ -27,7 +27,7 @@ export const VERSION: VersionTag = {
 export const METADATA = {
   build: buildMetadata,
   release: releaseMetadata,
-};
+} as const;
 
 const zeroDaoAddress = ethers.constants.AddressZero;
 const zeroTokenAddress = ethers.constants.AddressZero;

--- a/packages/contracts/src/ERC20/governance/GovernanceERC20.sol
+++ b/packages/contracts/src/ERC20/governance/GovernanceERC20.sol
@@ -55,11 +55,11 @@ contract GovernanceERC20 is
     /// @param amountsArrayLength The length of the `amounts` array.
     error MintSettingsArrayLengthMismatch(uint256 receiversArrayLength, uint256 amountsArrayLength);
 
-    /// @notice Thrown when an excluded account attempts to engage in voting activity.
-    error AccountIsExcluded();
-
     /// @notice Thrown when attempting to mint when minting is permanently disabled
     error MintingIsFrozen();
+
+    /// @notice Thrown when an excluded account attempts to engage in voting activity.
+    error AccountIsExcluded();
 
     /// @notice Calls the initialize function.
     /// @param _dao The managing DAO.

--- a/packages/contracts/src/ERC20/governance/GovernanceERC20.sol
+++ b/packages/contracts/src/ERC20/governance/GovernanceERC20.sol
@@ -32,19 +32,33 @@ contract GovernanceERC20 is
     /// @notice The permission identifier to mint new tokens
     bytes32 public constant MINT_PERMISSION_ID = keccak256("MINT_PERMISSION");
 
+    /// @notice The list of addresses excluded from voting
+    address[] public excludedAccounts;
+
     /// @notice The settings for the initial mint of the token.
     /// @param receivers The receivers of the tokens.
     /// @param amounts The amounts of tokens to be minted for each receiver.
+    /// @param amounts Wether each receiver should be excluded from voting purposes.
     /// @dev The lengths of `receivers` and `amounts` must match.
+    /// @dev `excluded` can be empty. Otherwise it must match the length of `receivers`.
     struct MintSettings {
         address[] receivers;
         uint256[] amounts;
+        bool[] excluded;
     }
 
     /// @notice Thrown if the number of receivers and amounts specified in the mint settings do not match.
     /// @param receiversArrayLength The length of the `receivers` array.
     /// @param amountsArrayLength The length of the `amounts` array.
-    error MintSettingsArrayLengthMismatch(uint256 receiversArrayLength, uint256 amountsArrayLength);
+    /// @param excludedArrayLength The length of the `excluded` array.
+    error MintSettingsArrayLengthMismatch(
+        uint256 receiversArrayLength,
+        uint256 amountsArrayLength,
+        uint256 excludedArrayLength
+    );
+
+    /// @notice Thrown when an excluded account attempts to engage in voting activity.
+    error ExcludedAccount();
 
     /// @notice Calls the initialize function.
     /// @param _dao The managing DAO.
@@ -75,7 +89,17 @@ contract GovernanceERC20 is
         if (_mintSettings.receivers.length != _mintSettings.amounts.length) {
             revert MintSettingsArrayLengthMismatch({
                 receiversArrayLength: _mintSettings.receivers.length,
-                amountsArrayLength: _mintSettings.amounts.length
+                amountsArrayLength: _mintSettings.amounts.length,
+                excludedArrayLength: _mintSettings.excluded.length
+            });
+        } else if (
+            _mintSettings.excluded.length > 0 &&
+            _mintSettings.receivers.length != _mintSettings.excluded.length
+        ) {
+            revert MintSettingsArrayLengthMismatch({
+                receiversArrayLength: _mintSettings.receivers.length,
+                amountsArrayLength: _mintSettings.amounts.length,
+                excludedArrayLength: _mintSettings.excluded.length
             });
         }
 
@@ -90,6 +114,11 @@ contract GovernanceERC20 is
                 ++i;
             }
         }
+        for (uint256 i; i < _mintSettings.excluded.length; ) {
+            if (!_mintSettings.excluded[i]) continue;
+
+            excludedAccounts.push(_mintSettings.receivers[i]);
+        }
     }
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
@@ -103,6 +132,41 @@ contract GovernanceERC20 is
             _interfaceId == type(IVotesUpgradeable).interfaceId ||
             _interfaceId == type(IERC20MintableUpgradeable).interfaceId ||
             super.supportsInterface(_interfaceId);
+    }
+
+    function delegate(address account) public override {
+        for (uint256 i; i < excludedAccounts.length; i++) {
+            if (msg.sender != excludedAccounts[i]) continue;
+
+            revert ExcludedAccount();
+        }
+        super.delegate(account);
+    }
+
+    /// @inheritdoc ERC20VotesUpgradeable
+    /// @dev This override extends the original implementation, ensuring that excluded addresses cannot use their voting power.
+    function getPastVotes(
+        address account,
+        uint256 timepoint
+    ) public view override returns (uint256) {
+        for (uint256 i; i < excludedAccounts.length; ++i) {
+            if (account == excludedAccounts[i]) {
+                return 0;
+            }
+        }
+        return super.getPastVotes(account, timepoint);
+    }
+
+    /// @inheritdoc ERC20VotesUpgradeable
+    /// @dev This override extends the original implementation, ensuring that excluded addresses cannot use their voting power.
+    function getPastTotalSupply(uint256 timepoint) public view override returns (uint256) {
+        uint256 excludedSupply = super.getPastVotes(address(0), timepoint);
+        for (uint256 i; i < excludedAccounts.length; ++i) {
+            /// @dev Using getPastVotes() even though these addresses cannot self delegate.
+            /// @dev Another account could transfer a delegated balance to them.
+            excludedSupply += super.getPastVotes(excludedAccounts[i], timepoint);
+        }
+        return super.getPastTotalSupply(timepoint) - excludedSupply;
     }
 
     /// @notice Mints tokens to an address.

--- a/packages/contracts/src/ERC20/governance/GovernanceERC20.sol
+++ b/packages/contracts/src/ERC20/governance/GovernanceERC20.sol
@@ -41,13 +41,10 @@ contract GovernanceERC20 is
     /// @notice The settings for the initial mint of the token.
     /// @param receivers The receivers of the tokens.
     /// @param amounts The amounts of tokens to be minted for each receiver.
-    /// @param amounts Wether each receiver should be excluded from voting purposes.
     /// @dev The lengths of `receivers` and `amounts` must match.
-    /// @dev `excluded` can be empty. Otherwise it must match the length of `receivers`.
     struct MintSettings {
         address[] receivers;
         uint256[] amounts;
-        bool[] excluded;
     }
 
     /// @notice Emitted when minting is frozen permanently
@@ -56,12 +53,7 @@ contract GovernanceERC20 is
     /// @notice Thrown if the number of receivers and amounts specified in the mint settings do not match.
     /// @param receiversArrayLength The length of the `receivers` array.
     /// @param amountsArrayLength The length of the `amounts` array.
-    /// @param excludedArrayLength The length of the `excluded` array.
-    error MintSettingsArrayLengthMismatch(
-        uint256 receiversArrayLength,
-        uint256 amountsArrayLength,
-        uint256 excludedArrayLength
-    );
+    error MintSettingsArrayLengthMismatch(uint256 receiversArrayLength, uint256 amountsArrayLength);
 
     /// @notice Thrown when an excluded account attempts to engage in voting activity.
     error AccountIsExcluded();
@@ -74,13 +66,15 @@ contract GovernanceERC20 is
     /// @param _name The name of the [ERC-20](https://eips.ethereum.org/EIPS/eip-20) governance token.
     /// @param _symbol The symbol of the [ERC-20](https://eips.ethereum.org/EIPS/eip-20) governance token.
     /// @param _mintSettings The token mint settings struct containing the `receivers` and `amounts`.
+    /// @param _excludedAccounts The list of accounts excluded from voting.
     constructor(
         IDAO _dao,
         string memory _name,
         string memory _symbol,
-        MintSettings memory _mintSettings
+        MintSettings memory _mintSettings,
+        address[] memory _excludedAccounts
     ) {
-        initialize(_dao, _name, _symbol, _mintSettings);
+        initialize(_dao, _name, _symbol, _mintSettings, _excludedAccounts);
     }
 
     /// @notice Initializes the contract and mints tokens to a list of receivers.
@@ -88,27 +82,19 @@ contract GovernanceERC20 is
     /// @param _name The name of the [ERC-20](https://eips.ethereum.org/EIPS/eip-20) governance token.
     /// @param _symbol The symbol of the [ERC-20](https://eips.ethereum.org/EIPS/eip-20) governance token.
     /// @param _mintSettings The token mint settings struct containing the `receivers` and `amounts`.
+    /// @param _excludedAccounts The list of accounts excluded from voting.
     function initialize(
         IDAO _dao,
         string memory _name,
         string memory _symbol,
-        MintSettings memory _mintSettings
+        MintSettings memory _mintSettings,
+        address[] memory _excludedAccounts
     ) public initializer {
         // Check mint settings
         if (_mintSettings.receivers.length != _mintSettings.amounts.length) {
             revert MintSettingsArrayLengthMismatch({
                 receiversArrayLength: _mintSettings.receivers.length,
-                amountsArrayLength: _mintSettings.amounts.length,
-                excludedArrayLength: _mintSettings.excluded.length
-            });
-        } else if (
-            _mintSettings.excluded.length > 0 &&
-            _mintSettings.receivers.length != _mintSettings.excluded.length
-        ) {
-            revert MintSettingsArrayLengthMismatch({
-                receiversArrayLength: _mintSettings.receivers.length,
-                amountsArrayLength: _mintSettings.amounts.length,
-                excludedArrayLength: _mintSettings.excluded.length
+                amountsArrayLength: _mintSettings.amounts.length
             });
         }
 
@@ -123,10 +109,8 @@ contract GovernanceERC20 is
                 ++i;
             }
         }
-        for (uint256 i; i < _mintSettings.excluded.length; ) {
-            if (!_mintSettings.excluded[i]) continue;
-
-            excludedAccounts.push(_mintSettings.receivers[i]);
+        for (uint256 i; i < _excludedAccounts.length; ) {
+            excludedAccounts.push(_excludedAccounts[i]);
 
             unchecked {
                 ++i;

--- a/packages/contracts/src/ERC20/governance/GovernanceERC20.sol
+++ b/packages/contracts/src/ERC20/governance/GovernanceERC20.sol
@@ -35,6 +35,9 @@ contract GovernanceERC20 is
     /// @notice The list of addresses excluded from voting
     address[] public excludedAccounts;
 
+    /// @notice Wether mint() has been permanently disabled
+    bool public mintingFrozen;
+
     /// @notice The settings for the initial mint of the token.
     /// @param receivers The receivers of the tokens.
     /// @param amounts The amounts of tokens to be minted for each receiver.
@@ -47,6 +50,9 @@ contract GovernanceERC20 is
         bool[] excluded;
     }
 
+    /// @notice Emitted when minting is frozen permanently
+    event MintingFrozen();
+
     /// @notice Thrown if the number of receivers and amounts specified in the mint settings do not match.
     /// @param receiversArrayLength The length of the `receivers` array.
     /// @param amountsArrayLength The length of the `amounts` array.
@@ -58,7 +64,10 @@ contract GovernanceERC20 is
     );
 
     /// @notice Thrown when an excluded account attempts to engage in voting activity.
-    error ExcludedAccount();
+    error AccountIsExcluded();
+
+    /// @notice Thrown when attempting to mint when minting is permanently disabled
+    error MintingIsFrozen();
 
     /// @notice Calls the initialize function.
     /// @param _dao The managing DAO.
@@ -142,7 +151,7 @@ contract GovernanceERC20 is
         for (uint256 i; i < excludedAccounts.length; i++) {
             if (msg.sender != excludedAccounts[i]) continue;
 
-            revert ExcludedAccount();
+            revert AccountIsExcluded();
         }
         super.delegate(account);
     }
@@ -177,7 +186,19 @@ contract GovernanceERC20 is
     /// @param to The address receiving the tokens.
     /// @param amount The amount of tokens to be minted.
     function mint(address to, uint256 amount) external override auth(MINT_PERMISSION_ID) {
+        if (mintingFrozen) {
+            revert MintingIsFrozen();
+        }
+
         _mint(to, amount);
+    }
+
+    /// @notice Disables the mint() function permanently.
+    function freezeMinting() external auth(MINT_PERMISSION_ID) {
+        if (mintingFrozen) return;
+
+        mintingFrozen = true;
+        emit MintingFrozen();
     }
 
     // https://forum.openzeppelin.com/t/self-delegation-in-erc20votes/17501/12?u=novaknole

--- a/packages/contracts/src/ERC20/governance/GovernanceERC20.sol
+++ b/packages/contracts/src/ERC20/governance/GovernanceERC20.sol
@@ -118,6 +118,10 @@ contract GovernanceERC20 is
             if (!_mintSettings.excluded[i]) continue;
 
             excludedAccounts.push(_mintSettings.receivers[i]);
+
+            unchecked {
+                ++i;
+            }
         }
     }
 

--- a/packages/contracts/src/ERC20/governance/GovernanceWrappedERC20.sol
+++ b/packages/contracts/src/ERC20/governance/GovernanceWrappedERC20.sol
@@ -40,26 +40,54 @@ contract GovernanceWrappedERC20 is
     ERC20VotesUpgradeable,
     ERC20WrapperUpgradeable
 {
+    /// @notice The list of addresses excluded from voting
+    address[] public excludedAccounts;
+
+    /// @notice Thrown when an excluded account attempts to engage in voting activity.
+    error ExcludedAccount();
+
+    /// @notice Thrown when attempting to mint on the wrapper, rather than the underlying token.
+    error MintUnavailable();
+
+    /// @notice Thrown when attempting to burn on the wrapper, rather than the underlying token.
+    error BurnUnavailable();
+
     /// @notice Calls the initialize function.
     /// @param _token The underlying [ERC-20](https://eips.ethereum.org/EIPS/eip-20) token.
     /// @param _name The name of the wrapped token.
     /// @param _symbol The symbol of the wrapped token.
-    constructor(IERC20Upgradeable _token, string memory _name, string memory _symbol) {
-        initialize(_token, _name, _symbol);
+    /// @param _excludedAccounts The list of accounts to exclude from voting
+    constructor(
+        IERC20Upgradeable _token,
+        string memory _name,
+        string memory _symbol,
+        address[] memory _excludedAccounts
+    ) {
+        initialize(_token, _name, _symbol, _excludedAccounts);
     }
 
     /// @notice Initializes the contract.
     /// @param _token The underlying [ERC-20](https://eips.ethereum.org/EIPS/eip-20) token.
     /// @param _name The name of the wrapped token.
     /// @param _symbol The symbol of the wrapped token.
+    /// @param _excludedAccounts The list of accounts to exclude from voting
     function initialize(
         IERC20Upgradeable _token,
         string memory _name,
-        string memory _symbol
+        string memory _symbol,
+        address[] memory _excludedAccounts
     ) public initializer {
         __ERC20_init(_name, _symbol);
         __ERC20Permit_init(_name);
         __ERC20Wrapper_init(_token);
+
+        for (uint256 i; i < _excludedAccounts.length; ) {
+            excludedAccounts.push(_excludedAccounts[i]);
+
+            unchecked {
+                ++i;
+            }
+        }
     }
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
@@ -84,6 +112,41 @@ contract GovernanceWrappedERC20 is
         returns (uint8)
     {
         return ERC20WrapperUpgradeable.decimals();
+    }
+
+    function delegate(address _account) public override {
+        for (uint256 i; i < excludedAccounts.length; i++) {
+            if (msg.sender != excludedAccounts[i]) continue;
+
+            revert ExcludedAccount();
+        }
+        super.delegate(_account);
+    }
+
+    /// @inheritdoc ERC20VotesUpgradeable
+    /// @dev This override extends the original implementation, ensuring that excluded addresses cannot use their voting power.
+    function getPastVotes(
+        address _account,
+        uint256 _timepoint
+    ) public view override returns (uint256) {
+        for (uint256 i; i < excludedAccounts.length; ++i) {
+            if (_account == excludedAccounts[i]) {
+                return 0;
+            }
+        }
+        return super.getPastVotes(_account, _timepoint);
+    }
+
+    /// @inheritdoc ERC20VotesUpgradeable
+    /// @dev This override extends the original implementation, ensuring that excluded addresses cannot use their voting power.
+    function getPastTotalSupply(uint256 _timepoint) public view override returns (uint256) {
+        uint256 _excludedSupply = super.getPastVotes(address(0), _timepoint);
+        for (uint256 i; i < excludedAccounts.length; ++i) {
+            /// @dev Using getPastVotes() even though these addresses cannot self delegate.
+            /// @dev Another account could transfer a delegated balance to them.
+            _excludedSupply += super.getPastVotes(excludedAccounts[i], _timepoint);
+        }
+        return super.getPastTotalSupply(_timepoint) - _excludedSupply;
     }
 
     /// @inheritdoc IGovernanceWrappedERC20
@@ -119,17 +182,23 @@ contract GovernanceWrappedERC20 is
 
     /// @inheritdoc ERC20VotesUpgradeable
     function _mint(
-        address to,
-        uint256 amount
-    ) internal override(ERC20VotesUpgradeable, ERC20Upgradeable) {
-        super._mint(to, amount);
+        address _to,
+        uint256 _amount
+    ) internal pure override(ERC20VotesUpgradeable, ERC20Upgradeable) {
+        // Silence the warning
+        (_to, _amount);
+
+        revert MintUnavailable();
     }
 
     /// @inheritdoc ERC20VotesUpgradeable
     function _burn(
-        address account,
-        uint256 amount
-    ) internal override(ERC20VotesUpgradeable, ERC20Upgradeable) {
-        super._burn(account, amount);
+        address _account,
+        uint256 _amount
+    ) internal pure override(ERC20VotesUpgradeable, ERC20Upgradeable) {
+        // Silence the warning
+        (_account, _amount);
+
+        revert BurnUnavailable();
     }
 }

--- a/packages/contracts/src/ERC20/governance/GovernanceWrappedERC20.sol
+++ b/packages/contracts/src/ERC20/governance/GovernanceWrappedERC20.sol
@@ -44,7 +44,7 @@ contract GovernanceWrappedERC20 is
     address[] public excludedAccounts;
 
     /// @notice Thrown when an excluded account attempts to engage in voting activity.
-    error ExcludedAccount();
+    error AccountIsExcluded();
 
     /// @notice Thrown when attempting to mint on the wrapper, rather than the underlying token.
     error MintUnavailable();
@@ -118,7 +118,7 @@ contract GovernanceWrappedERC20 is
         for (uint256 i; i < excludedAccounts.length; i++) {
             if (msg.sender != excludedAccounts[i]) continue;
 
-            revert ExcludedAccount();
+            revert AccountIsExcluded();
         }
         super.delegate(_account);
     }

--- a/packages/contracts/src/ERC20/governance/GovernanceWrappedERC20.sol
+++ b/packages/contracts/src/ERC20/governance/GovernanceWrappedERC20.sol
@@ -46,12 +46,6 @@ contract GovernanceWrappedERC20 is
     /// @notice Thrown when an excluded account attempts to engage in voting activity.
     error AccountIsExcluded();
 
-    /// @notice Thrown when attempting to mint on the wrapper, rather than the underlying token.
-    error MintUnavailable();
-
-    /// @notice Thrown when attempting to burn on the wrapper, rather than the underlying token.
-    error BurnUnavailable();
-
     /// @notice Calls the initialize function.
     /// @param _token The underlying [ERC-20](https://eips.ethereum.org/EIPS/eip-20) token.
     /// @param _name The name of the wrapped token.

--- a/packages/contracts/src/ERC20/governance/GovernanceWrappedERC20.sol
+++ b/packages/contracts/src/ERC20/governance/GovernanceWrappedERC20.sol
@@ -182,23 +182,17 @@ contract GovernanceWrappedERC20 is
 
     /// @inheritdoc ERC20VotesUpgradeable
     function _mint(
-        address _to,
-        uint256 _amount
-    ) internal pure override(ERC20VotesUpgradeable, ERC20Upgradeable) {
-        // Silence the warning
-        (_to, _amount);
-
-        revert MintUnavailable();
+        address to,
+        uint256 amount
+    ) internal override(ERC20VotesUpgradeable, ERC20Upgradeable) {
+        super._mint(to, amount);
     }
 
     /// @inheritdoc ERC20VotesUpgradeable
     function _burn(
-        address _account,
-        uint256 _amount
-    ) internal pure override(ERC20VotesUpgradeable, ERC20Upgradeable) {
-        // Silence the warning
-        (_account, _amount);
-
-        revert BurnUnavailable();
+        address account,
+        uint256 amount
+    ) internal override(ERC20VotesUpgradeable, ERC20Upgradeable) {
+        super._burn(account, amount);
     }
 }

--- a/packages/contracts/src/MajorityVotingBase.sol
+++ b/packages/contracts/src/MajorityVotingBase.sol
@@ -192,7 +192,7 @@ abstract contract MajorityVotingBase is
     ///     The value has to be in the interval [0, 10^6] defined by `RATIO_BASE = 10**6`.
     /// @param startDate The start date of the proposal vote.
     /// @param endDate The end date of the proposal vote.
-    /// @param snapshotTimepoint The number of the block prior to the proposal creation.
+    /// @param snapshotTimepoint The block number or timestamp prior to the proposal creation.
     /// @param minVotingPower The minimum voting power needed for a proposal to reach minimum participation.
     struct ProposalParameters {
         VotingMode votingMode;

--- a/packages/contracts/src/MajorityVotingBase.sol
+++ b/packages/contracts/src/MajorityVotingBase.sol
@@ -192,14 +192,14 @@ abstract contract MajorityVotingBase is
     ///     The value has to be in the interval [0, 10^6] defined by `RATIO_BASE = 10**6`.
     /// @param startDate The start date of the proposal vote.
     /// @param endDate The end date of the proposal vote.
-    /// @param snapshotBlock The number of the block prior to the proposal creation.
+    /// @param snapshotTimepoint The number of the block prior to the proposal creation.
     /// @param minVotingPower The minimum voting power needed for a proposal to reach minimum participation.
     struct ProposalParameters {
         VotingMode votingMode;
         uint32 supportThreshold;
         uint64 startDate;
         uint64 endDate;
-        uint64 snapshotBlock;
+        uint64 snapshotTimepoint;
         uint256 minVotingPower;
     }
 
@@ -453,7 +453,7 @@ abstract contract MajorityVotingBase is
     ) public view virtual returns (bool) {
         Proposal storage proposal_ = proposals[_proposalId];
 
-        uint256 noVotesWorstCase = totalVotingPower(proposal_.parameters.snapshotBlock) -
+        uint256 noVotesWorstCase = totalVotingPower(proposal_.parameters.snapshotTimepoint) -
             proposal_.tally.yes -
             proposal_.tally.abstain;
 
@@ -752,7 +752,7 @@ abstract contract MajorityVotingBase is
     /// @param _proposalId The ID of the proposal.
     /// @return Returns `true` if proposal exists, otherwise false.
     function _proposalExists(uint256 _proposalId) private view returns (bool) {
-        return proposals[_proposalId].parameters.snapshotBlock != 0;
+        return proposals[_proposalId].parameters.snapshotTimepoint != 0;
     }
 
     /// @notice Internal function to update minimal approval value.

--- a/packages/contracts/src/TokenVoting.sol
+++ b/packages/contracts/src/TokenVoting.sol
@@ -97,7 +97,7 @@ contract TokenVoting is IMembership, MajorityVotingBase {
     /// @param _fromBuild Build version number of previous implementation contract this upgrade is transitioning from.
     /// @param _initData The initialization data to be passed to via `upgradeToAndCall`
     ///     (see [ERC-1967](https://docs.openzeppelin.com/contracts/4.x/api/proxy#ERC1967Upgrade)).
-    function initializeFrom(uint16 _fromBuild, bytes calldata _initData) external reinitializer(2) {
+    function initializeFrom(uint16 _fromBuild, bytes calldata _initData) external reinitializer(3) {
         if (_fromBuild < 3) {
             (
                 uint256 minApprovals,

--- a/packages/contracts/src/TokenVoting.sol
+++ b/packages/contracts/src/TokenVoting.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.8;
 import {IVotesUpgradeable} from "@openzeppelin/contracts-upgradeable/governance/utils/IVotesUpgradeable.sol";
 import {SafeCastUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
 import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import {IERC6372Upgradeable} from "@openzeppelin/contracts-upgradeable/interfaces/IERC6372Upgradeable.sol";
 
 import {IMembership} from "@aragon/osx-commons-contracts/src/plugin/extensions/membership/IMembership.sol";
 import {_applyRatioCeiled} from "@aragon/osx-commons-contracts/src/utils/math/Ratio.sol";
@@ -33,6 +34,9 @@ contract TokenVoting is IMembership, MajorityVotingBase {
     ///         compatible contract referencing the token being used for voting.
     IVotesUpgradeable private votingToken;
 
+    /// @notice Wether the token contract indexes past voting power by timestamp.
+    bool private tokenIndexedByTimestamp;
+
     /// @notice Thrown if the voting power is zero
     error NoVotingPower();
 
@@ -54,7 +58,7 @@ contract TokenVoting is IMembership, MajorityVotingBase {
         TargetConfig calldata _targetConfig,
         uint256 _minApprovals,
         bytes calldata _pluginMetadata
-    ) external onlyCallAtInitialization reinitializer(2) {
+    ) external onlyCallAtInitialization reinitializer(3) {
         __MajorityVotingBase_init(
             _dao,
             _votingSettings,
@@ -64,6 +68,23 @@ contract TokenVoting is IMembership, MajorityVotingBase {
         );
 
         votingToken = _token;
+
+        // Check if the given token indexes past voting power by blocks or by timestamp
+        try IERC6372Upgradeable(address(_token)).CLOCK_MODE() returns (string memory ms) {
+            if (keccak256(bytes(ms)) == keccak256(bytes("mode=timestamp&version=1"))) {
+                tokenIndexedByTimestamp = true;
+            }
+        } catch {
+            // CLOCK_MODE() not found, reverted, or other issue.
+            try IERC6372Upgradeable(address(_token)).clock() returns (uint48 cv) {
+                if (cv == block.timestamp) {
+                    tokenIndexedByTimestamp = true;
+                }
+            } catch {
+                // clock() not found, reverted, or other issue.
+                // Assuming that the token indexes by block number
+            }
+        }
 
         emit MembershipContractAnnounced({definingContract: address(_token)});
     }
@@ -126,14 +147,18 @@ contract TokenVoting is IMembership, MajorityVotingBase {
         VoteOption _voteOption,
         bool _tryEarlyExecution
     ) public override auth(CREATE_PROPOSAL_PERMISSION_ID) returns (uint256 proposalId) {
-        uint256 snapshotBlock;
+        uint256 snapshotTimepoint;
         unchecked {
-            // The snapshot block must be mined already to
-            // protect the transaction against backrunning transactions causing census changes.
-            snapshotBlock = block.number - 1;
+            // The time point must be already mined (block) or in the past (timestamp) to
+            // protect against backrunning transactions causing census changes.
+            if (tokenIndexedByTimestamp) {
+                snapshotTimepoint = block.timestamp - 1;
+            } else {
+                snapshotTimepoint = block.number - 1;
+            }
         }
 
-        uint256 totalVotingPower_ = totalVotingPower(snapshotBlock);
+        uint256 totalVotingPower_ = totalVotingPower(snapshotTimepoint);
 
         if (totalVotingPower_ == 0) {
             revert NoVotingPower();
@@ -146,13 +171,13 @@ contract TokenVoting is IMembership, MajorityVotingBase {
         // Store proposal related information
         Proposal storage proposal_ = proposals[proposalId];
 
-        if (proposal_.parameters.snapshotBlock != 0) {
+        if (proposal_.parameters.snapshotTimepoint != 0) {
             revert ProposalAlreadyExists(proposalId);
         }
 
         proposal_.parameters.startDate = _startDate;
         proposal_.parameters.endDate = _endDate;
-        proposal_.parameters.snapshotBlock = snapshotBlock.toUint64();
+        proposal_.parameters.snapshotTimepoint = snapshotTimepoint.toUint64();
         proposal_.parameters.votingMode = votingMode();
         proposal_.parameters.supportThreshold = supportThreshold();
         proposal_.parameters.minVotingPower = _applyRatioCeiled(
@@ -244,7 +269,10 @@ contract TokenVoting is IMembership, MajorityVotingBase {
         Proposal storage proposal_ = proposals[_proposalId];
 
         // This could re-enter, though we can assume the governance token is not malicious
-        uint256 votingPower = votingToken.getPastVotes(_voter, proposal_.parameters.snapshotBlock);
+        uint256 votingPower = votingToken.getPastVotes(
+            _voter,
+            proposal_.parameters.snapshotTimepoint
+        );
         VoteOption state = proposal_.voters[_voter];
 
         // If voter had previously voted, decrease count
@@ -305,7 +333,7 @@ contract TokenVoting is IMembership, MajorityVotingBase {
         }
 
         // The voter has no voting power.
-        if (votingToken.getPastVotes(_account, proposal_.parameters.snapshotBlock) == 0) {
+        if (votingToken.getPastVotes(_account, proposal_.parameters.snapshotTimepoint) == 0) {
             return false;
         }
 
@@ -343,5 +371,5 @@ contract TokenVoting is IMembership, MajorityVotingBase {
     /// @dev This empty reserved space is put in place to allow future versions to add new
     /// variables without shifting down storage in the inheritance chain.
     /// https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
-    uint256[49] private __gap;
+    uint256[48] private __gap;
 }

--- a/packages/contracts/src/TokenVotingSetup.sol
+++ b/packages/contracts/src/TokenVotingSetup.sol
@@ -114,18 +114,9 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
             GovernanceERC20.MintSettings memory mintSettings,
             IPlugin.TargetConfig memory targetConfig,
             uint256 minApprovals,
-            bytes memory pluginMetadata
-        ) = abi.decode(
-                _data,
-                (
-                    MajorityVotingBase.VotingSettings,
-                    TokenSettings,
-                    GovernanceERC20.MintSettings,
-                    IPlugin.TargetConfig,
-                    uint256,
-                    bytes
-                )
-            );
+            bytes memory pluginMetadata,
+            address[] memory excludedAccounts
+        ) = decodeInstallationParameters(_data);
 
         address token = tokenSettings.addr;
 
@@ -149,7 +140,7 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
                     IERC20Upgradeable(tokenSettings.addr),
                     tokenSettings.name,
                     tokenSettings.symbol,
-                    new address[](0)
+                    excludedAccounts
                 );
             }
         } else {
@@ -159,7 +150,8 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
                 IDAO(_dao),
                 tokenSettings.name,
                 tokenSettings.symbol,
-                mintSettings
+                mintSettings,
+                excludedAccounts
             );
         }
 
@@ -396,6 +388,61 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
             data2.length == 0x20 &&
             success3 &&
             data3.length == 0x20);
+    }
+
+    /// @notice Encodes the given installation parameters into a byte array
+    function encodeInstallationParameters(
+        MajorityVotingBase.VotingSettings memory votingSettings,
+        TokenSettings memory tokenSettings,
+        // only used for GovernanceERC20(token is not passed)
+        GovernanceERC20.MintSettings memory mintSettings,
+        IPlugin.TargetConfig memory targetConfig,
+        uint256 minApprovals,
+        bytes memory pluginMetadata,
+        address[] memory excludedAccounts
+    ) external pure returns (bytes memory) {
+        return
+            abi.encode(
+                votingSettings,
+                tokenSettings,
+                mintSettings,
+                targetConfig,
+                minApprovals,
+                pluginMetadata,
+                excludedAccounts
+            );
+    }
+
+    /// @notice Decodes the given byte array into the original installation parameters
+    function decodeInstallationParameters(
+        bytes memory _data
+    )
+        public
+        pure
+        returns (
+            MajorityVotingBase.VotingSettings memory votingSettings,
+            TokenSettings memory tokenSettings,
+            // only used for GovernanceERC20(token is not passed)
+            GovernanceERC20.MintSettings memory mintSettings,
+            IPlugin.TargetConfig memory targetConfig,
+            uint256 minApprovals,
+            bytes memory pluginMetadata,
+            address[] memory excludedAccounts
+        )
+    {
+        return
+            abi.decode(
+                _data,
+                (
+                    MajorityVotingBase.VotingSettings,
+                    TokenSettings,
+                    GovernanceERC20.MintSettings,
+                    IPlugin.TargetConfig,
+                    uint256,
+                    bytes,
+                    address[]
+                )
+            );
     }
 
     /// @notice Unsatisfiably determines if the contract is an ERC20 token.

--- a/packages/contracts/src/TokenVotingSetup.sol
+++ b/packages/contracts/src/TokenVotingSetup.sol
@@ -105,74 +105,86 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
         address _dao,
         bytes calldata _data
     ) external returns (address plugin, PreparedSetupData memory preparedSetupData) {
-        // Decode `_data` to extract the params needed for deploying and initializing `TokenVoting` plugin,
-        // and the required helpers
-        (
-            MajorityVotingBase.VotingSettings memory votingSettings,
-            TokenSettings memory tokenSettings,
-            // only used for GovernanceERC20(token is not passed)
-            GovernanceERC20.MintSettings memory mintSettings,
-            IPlugin.TargetConfig memory targetConfig,
-            uint256 minApprovals,
-            bytes memory pluginMetadata,
-            address[] memory excludedAccounts
-        ) = decodeInstallationParameters(_data);
+        TokenSettings memory tokenSettings;
+        address token;
 
-        address token = tokenSettings.addr;
+        {
+            MajorityVotingBase.VotingSettings memory votingSettings;
+            GovernanceERC20.MintSettings memory mintSettings;
+            IPlugin.TargetConfig memory targetConfig;
+            uint256 minApprovals;
+            bytes memory pluginMetadata;
+            address[] memory excludedAccounts;
 
-        // Use the given token
-        if (token != address(0)) {
-            if (!token.isContract()) {
-                revert TokenNotContract(token);
-            }
+            // Decode `_data` to extract the params needed for deploying and initializing `TokenVoting` plugin,
+            // and the required helpers
+            (
+                votingSettings,
+                tokenSettings,
+                // only used for GovernanceERC20(token is not passed)
+                mintSettings,
+                targetConfig,
+                minApprovals,
+                pluginMetadata,
+                excludedAccounts
+            ) = decodeInstallationParameters(_data);
 
-            if (!_isERC20(token)) {
-                revert TokenNotERC20(token);
-            }
+            token = tokenSettings.addr;
 
-            if (!supportsIVotesInterface(token)) {
-                token = governanceWrappedERC20Base.clone();
+            // Use the given token
+            if (token != address(0)) {
+                if (!token.isContract()) {
+                    revert TokenNotContract(token);
+                }
 
-                // User already has a token. We need to wrap it in
-                // GovernanceWrappedERC20 in order to make the token
-                // include governance functionality.
-                GovernanceWrappedERC20(token).initialize(
-                    IERC20Upgradeable(tokenSettings.addr),
+                if (!_isERC20(token)) {
+                    revert TokenNotERC20(token);
+                }
+
+                if (!supportsIVotesInterface(token)) {
+                    token = governanceWrappedERC20Base.clone();
+
+                    // User already has a token. We need to wrap it in
+                    // GovernanceWrappedERC20 in order to make the token
+                    // include governance functionality.
+                    GovernanceWrappedERC20(token).initialize(
+                        IERC20Upgradeable(tokenSettings.addr),
+                        tokenSettings.name,
+                        tokenSettings.symbol,
+                        excludedAccounts
+                    );
+                }
+            } else {
+                // Create a new token: Clone a `GovernanceERC20`.
+                token = governanceERC20Base.clone();
+                GovernanceERC20(token).initialize(
+                    IDAO(_dao),
                     tokenSettings.name,
                     tokenSettings.symbol,
+                    mintSettings,
                     excludedAccounts
                 );
             }
-        } else {
-            // Create a new token: Clone a `GovernanceERC20`.
-            token = governanceERC20Base.clone();
-            GovernanceERC20(token).initialize(
-                IDAO(_dao),
-                tokenSettings.name,
-                tokenSettings.symbol,
-                mintSettings,
-                excludedAccounts
-            );
-        }
 
-        // Prepare and deploy plugin proxy.
-        plugin = address(tokenVotingBase).deployUUPSProxy(
-            abi.encodeCall(
-                TokenVoting.initialize,
-                (
-                    IDAO(_dao),
-                    votingSettings,
-                    IVotesUpgradeable(token),
-                    targetConfig,
-                    minApprovals,
-                    pluginMetadata
+            // Prepare and deploy plugin proxy.
+            plugin = address(tokenVotingBase).deployUUPSProxy(
+                abi.encodeCall(
+                    TokenVoting.initialize,
+                    (
+                        IDAO(_dao),
+                        votingSettings,
+                        IVotesUpgradeable(token),
+                        targetConfig,
+                        minApprovals,
+                        pluginMetadata
+                    )
                 )
-            )
-        );
+            );
 
-        preparedSetupData.helpers = new address[](2);
-        preparedSetupData.helpers[0] = address(new VotingPowerCondition(plugin));
-        preparedSetupData.helpers[1] = token;
+            preparedSetupData.helpers = new address[](2);
+            preparedSetupData.helpers[0] = address(new VotingPowerCondition(plugin));
+            preparedSetupData.helpers[1] = token;
+        }
 
         // Prepare permissions
         PermissionLib.MultiTargetPermission[]

--- a/packages/contracts/src/TokenVotingSetup.sol
+++ b/packages/contracts/src/TokenVotingSetup.sol
@@ -129,7 +129,8 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
 
         address token = tokenSettings.addr;
 
-        if (tokenSettings.addr != address(0)) {
+        // Use the given token
+        if (token != address(0)) {
             if (!token.isContract()) {
                 revert TokenNotContract(token);
             }
@@ -140,17 +141,19 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
 
             if (!supportsIVotesInterface(token)) {
                 token = governanceWrappedERC20Base.clone();
+
                 // User already has a token. We need to wrap it in
                 // GovernanceWrappedERC20 in order to make the token
                 // include governance functionality.
                 GovernanceWrappedERC20(token).initialize(
                     IERC20Upgradeable(tokenSettings.addr),
                     tokenSettings.name,
-                    tokenSettings.symbol
+                    tokenSettings.symbol,
+                    new address[](0)
                 );
             }
         } else {
-            // Clone a `GovernanceERC20`.
+            // Create a new token: Clone a `GovernanceERC20`.
             token = governanceERC20Base.clone();
             GovernanceERC20(token).initialize(
                 IDAO(_dao),

--- a/packages/contracts/src/TokenVotingSetupZkSync.sol
+++ b/packages/contracts/src/TokenVotingSetupZkSync.sol
@@ -98,18 +98,9 @@ contract TokenVotingSetupZkSync is PluginUpgradeableSetup {
             GovernanceERC20.MintSettings memory mintSettings,
             IPlugin.TargetConfig memory targetConfig,
             uint256 minApprovals,
-            bytes memory pluginMetadata
-        ) = abi.decode(
-                _data,
-                (
-                    MajorityVotingBase.VotingSettings,
-                    TokenSettings,
-                    GovernanceERC20.MintSettings,
-                    IPlugin.TargetConfig,
-                    uint256,
-                    bytes
-                )
-            );
+            bytes memory pluginMetadata,
+            address[] memory excludedAccounts
+        ) = decodeInstallationParameters(_data);
 
         address token = tokenSettings.addr;
 
@@ -127,7 +118,8 @@ contract TokenVotingSetupZkSync is PluginUpgradeableSetup {
                     new GovernanceWrappedERC20(
                         IERC20Upgradeable(tokenSettings.addr),
                         tokenSettings.name,
-                        tokenSettings.symbol
+                        tokenSettings.symbol,
+                        excludedAccounts
                     )
                 );
             }
@@ -137,7 +129,8 @@ contract TokenVotingSetupZkSync is PluginUpgradeableSetup {
                     IDAO(_dao),
                     tokenSettings.name,
                     tokenSettings.symbol,
-                    mintSettings
+                    mintSettings,
+                    excludedAccounts
                 )
             );
         }
@@ -375,6 +368,61 @@ contract TokenVotingSetupZkSync is PluginUpgradeableSetup {
             data2.length == 0x20 &&
             success3 &&
             data3.length == 0x20);
+    }
+
+    /// @notice Encodes the given installation parameters into a byte array
+    function encodeInstallationParameters(
+        MajorityVotingBase.VotingSettings memory votingSettings,
+        TokenSettings memory tokenSettings,
+        // only used for GovernanceERC20(token is not passed)
+        GovernanceERC20.MintSettings memory mintSettings,
+        IPlugin.TargetConfig memory targetConfig,
+        uint256 minApprovals,
+        bytes memory pluginMetadata,
+        address[] memory excludedAccounts
+    ) external pure returns (bytes memory) {
+        return
+            abi.encode(
+                votingSettings,
+                tokenSettings,
+                mintSettings,
+                targetConfig,
+                minApprovals,
+                pluginMetadata,
+                excludedAccounts
+            );
+    }
+
+    /// @notice Decodes the given byte array into the original installation parameters
+    function decodeInstallationParameters(
+        bytes memory _data
+    )
+        public
+        pure
+        returns (
+            MajorityVotingBase.VotingSettings memory votingSettings,
+            TokenSettings memory tokenSettings,
+            // only used for GovernanceERC20(token is not passed)
+            GovernanceERC20.MintSettings memory mintSettings,
+            IPlugin.TargetConfig memory targetConfig,
+            uint256 minApprovals,
+            bytes memory pluginMetadata,
+            address[] memory excludedAccounts
+        )
+    {
+        return
+            abi.decode(
+                _data,
+                (
+                    MajorityVotingBase.VotingSettings,
+                    TokenSettings,
+                    GovernanceERC20.MintSettings,
+                    IPlugin.TargetConfig,
+                    uint256,
+                    bytes,
+                    address[]
+                )
+            );
     }
 
     /// @notice Unsatisfiably determines if the contract is an ERC20 token.

--- a/packages/contracts/src/TokenVotingSetupZkSync.sol
+++ b/packages/contracts/src/TokenVotingSetupZkSync.sol
@@ -113,7 +113,7 @@ contract TokenVotingSetupZkSync is PluginUpgradeableSetup {
                 excludedAccounts
             ) = decodeInstallationParameters(_data);
 
-            address token = tokenSettings.addr;
+            token = tokenSettings.addr;
 
             if (token != address(0)) {
                 if (!token.isContract()) {

--- a/packages/contracts/src/TokenVotingSetupZkSync.sol
+++ b/packages/contracts/src/TokenVotingSetupZkSync.sol
@@ -89,70 +89,82 @@ contract TokenVotingSetupZkSync is PluginUpgradeableSetup {
         address _dao,
         bytes calldata _data
     ) external returns (address plugin, PreparedSetupData memory preparedSetupData) {
-        // Decode `_data` to extract the params needed for deploying and initializing `TokenVoting` plugin,
-        // and the required helpers
-        (
-            MajorityVotingBase.VotingSettings memory votingSettings,
-            TokenSettings memory tokenSettings,
-            // only used for GovernanceERC20(token is not passed)
-            GovernanceERC20.MintSettings memory mintSettings,
-            IPlugin.TargetConfig memory targetConfig,
-            uint256 minApprovals,
-            bytes memory pluginMetadata,
-            address[] memory excludedAccounts
-        ) = decodeInstallationParameters(_data);
+        TokenSettings memory tokenSettings;
+        address token;
 
-        address token = tokenSettings.addr;
+        {
+            MajorityVotingBase.VotingSettings memory votingSettings;
+            GovernanceERC20.MintSettings memory mintSettings;
+            IPlugin.TargetConfig memory targetConfig;
+            uint256 minApprovals;
+            bytes memory pluginMetadata;
+            address[] memory excludedAccounts;
 
-        if (tokenSettings.addr != address(0)) {
-            if (!token.isContract()) {
-                revert TokenNotContract(token);
-            }
+            // Decode `_data` to extract the params needed for deploying and initializing `TokenVoting` plugin,
+            // and the required helpers
+            (
+                votingSettings,
+                tokenSettings,
+                // only used for GovernanceERC20(token is not passed)
+                mintSettings,
+                targetConfig,
+                minApprovals,
+                pluginMetadata,
+                excludedAccounts
+            ) = decodeInstallationParameters(_data);
 
-            if (!_isERC20(token)) {
-                revert TokenNotERC20(token);
-            }
+            address token = tokenSettings.addr;
 
-            if (!supportsIVotesInterface(token)) {
+            if (token != address(0)) {
+                if (!token.isContract()) {
+                    revert TokenNotContract(token);
+                }
+
+                if (!_isERC20(token)) {
+                    revert TokenNotERC20(token);
+                }
+
+                if (!supportsIVotesInterface(token)) {
+                    token = address(
+                        new GovernanceWrappedERC20(
+                            IERC20Upgradeable(tokenSettings.addr),
+                            tokenSettings.name,
+                            tokenSettings.symbol,
+                            excludedAccounts
+                        )
+                    );
+                }
+            } else {
                 token = address(
-                    new GovernanceWrappedERC20(
-                        IERC20Upgradeable(tokenSettings.addr),
+                    new GovernanceERC20(
+                        IDAO(_dao),
                         tokenSettings.name,
                         tokenSettings.symbol,
+                        mintSettings,
                         excludedAccounts
                     )
                 );
             }
-        } else {
-            token = address(
-                new GovernanceERC20(
-                    IDAO(_dao),
-                    tokenSettings.name,
-                    tokenSettings.symbol,
-                    mintSettings,
-                    excludedAccounts
+
+            // Prepare and deploy plugin proxy.
+            plugin = address(tokenVotingBase).deployUUPSProxy(
+                abi.encodeCall(
+                    TokenVoting.initialize,
+                    (
+                        IDAO(_dao),
+                        votingSettings,
+                        IVotesUpgradeable(token),
+                        targetConfig,
+                        minApprovals,
+                        pluginMetadata
+                    )
                 )
             );
+
+            preparedSetupData.helpers = new address[](2);
+            preparedSetupData.helpers[0] = address(new VotingPowerCondition(plugin));
+            preparedSetupData.helpers[1] = token;
         }
-
-        // Prepare and deploy plugin proxy.
-        plugin = address(tokenVotingBase).deployUUPSProxy(
-            abi.encodeCall(
-                TokenVoting.initialize,
-                (
-                    IDAO(_dao),
-                    votingSettings,
-                    IVotesUpgradeable(token),
-                    targetConfig,
-                    minApprovals,
-                    pluginMetadata
-                )
-            )
-        );
-
-        preparedSetupData.helpers = new address[](2);
-        preparedSetupData.helpers[0] = address(new VotingPowerCondition(plugin));
-        preparedSetupData.helpers[1] = token;
 
         // Prepare permissions
         PermissionLib.MultiTargetPermission[]

--- a/packages/contracts/src/build-metadata.json
+++ b/packages/contracts/src/build-metadata.json
@@ -120,6 +120,12 @@
           "type": "bytes",
           "internalType": "bytes",
           "description": "The metadata that contains the information about the token voting plugin."
+        },
+        {
+          "name": "excludedAccounts",
+          "type": "address[]",
+          "internalType": "address[]",
+          "description": "The list of addresses whose voting power will be excluded from voting."
         }
       ]
     },
@@ -168,6 +174,10 @@
             "description": "The metadata that contains the information about the token voting plugin."
           }
         ]
+      },
+      "4": {
+        "description": "The information required for the update.",
+        "inputs": []
       }
     },
     "prepareUninstallation": {

--- a/packages/contracts/src/mocks/Migration.sol
+++ b/packages/contracts/src/mocks/Migration.sol
@@ -21,14 +21,17 @@ import {DAO} from "@aragon/osx/core/dao/DAO.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 // Regression Testing
-import {TokenVoting as TokenVoting_v1_0_0} from "@aragon/osx-v1.0.0/plugins/governance/majority-voting/token/TokenVoting.sol";
-import {TokenVoting as TokenVoting_v1_3_0} from "@aragon/osx-v1.3.0/plugins/governance/majority-voting/token/TokenVoting.sol";
+import {TokenVoting as TokenVoting_r1_b1} from "@aragon/osx-v1.0.0/plugins/governance/majority-voting/token/TokenVoting.sol";
+import {TokenVoting as TokenVoting_r1_b2} from "@aragon/osx-v1.3.0/plugins/governance/majority-voting/token/TokenVoting.sol";
+import {TokenVoting as TokenVoting_r1_b3} from "@aragon/token-voting-plugin-r1-b3/src/TokenVoting.sol";
 
-import {GovernanceERC20 as GovernanceERC20_v1_0_0} from "@aragon/osx-v1.0.0/token/ERC20/governance/GovernanceERC20.sol";
-import {GovernanceERC20 as GovernanceERC20_v1_3_0} from "@aragon/osx-v1.3.0/token/ERC20/governance/GovernanceERC20.sol";
+import {GovernanceERC20 as GovernanceERC20_r1_b1} from "@aragon/osx-v1.0.0/token/ERC20/governance/GovernanceERC20.sol";
+import {GovernanceERC20 as GovernanceERC20_r1_b2} from "@aragon/osx-v1.3.0/token/ERC20/governance/GovernanceERC20.sol";
+import {GovernanceERC20 as GovernanceERC20_r1_b3} from "@aragon/token-voting-plugin-r1-b3/src/ERC20/governance/GovernanceERC20.sol";
 
-import {GovernanceWrappedERC20 as GovernanceWrappedERC20_v1_0_0} from "@aragon/osx-v1.0.0/token/ERC20/governance/GovernanceWrappedERC20.sol";
-import {GovernanceWrappedERC20 as GovernanceWrappedERC20_v1_3_0} from "@aragon/osx-v1.3.0/token/ERC20/governance/GovernanceWrappedERC20.sol";
+import {GovernanceWrappedERC20 as GovernanceWrappedERC20_r1_b1} from "@aragon/osx-v1.0.0/token/ERC20/governance/GovernanceWrappedERC20.sol";
+import {GovernanceWrappedERC20 as GovernanceWrappedERC20_r1_b2} from "@aragon/osx-v1.3.0/token/ERC20/governance/GovernanceWrappedERC20.sol";
+import {GovernanceWrappedERC20 as GovernanceWrappedERC20_r1_b3} from "@aragon/token-voting-plugin-r1-b3/src/ERC20/governance/GovernanceWrappedERC20.sol";
 
 import {ProxyFactory} from "@aragon/osx-commons-contracts/src/utils/deployment/ProxyFactory.sol";
 

--- a/packages/contracts/src/mocks/TestGovernanceERC20.sol
+++ b/packages/contracts/src/mocks/TestGovernanceERC20.sol
@@ -15,8 +15,9 @@ contract TestGovernanceERC20 is GovernanceERC20 {
         IDAO _dao,
         string memory _name,
         string memory _symbol,
-        MintSettings memory _mintSettings
-    ) GovernanceERC20(_dao, _name, _symbol, _mintSettings) {}
+        MintSettings memory _mintSettings,
+        address[] memory _excludedAccounts
+    ) GovernanceERC20(_dao, _name, _symbol, _mintSettings, _excludedAccounts) {}
 
     // sets the balance of the address
     // this mints/burns the amount depending on the current balance

--- a/packages/contracts/test/10_unit-testing/11_plugin.ts
+++ b/packages/contracts/test/10_unit-testing/11_plugin.ts
@@ -29,8 +29,6 @@ import {
   TOKEN_VOTING_INTERFACE,
   UPDATE_VOTING_SETTINGS_PERMISSION_ID,
   EXECUTE_PROPOSAL_PERMISSION_ID,
-  INITIALIZE_SIGNATURE,
-  INITIALIZE_SIGNATURE_OLD,
   Operation,
   TargetConfig,
   CREATE_PROPOSAL_SIGNATURE,
@@ -150,6 +148,7 @@ async function globalFixture(): Promise<GlobalFixtureResult> {
         receivers: [],
         amounts: [],
       },
+      [],
     ],
   });
 
@@ -171,7 +170,7 @@ async function globalFixture(): Promise<GlobalFixtureResult> {
     operation: Operation.call,
   };
 
-  const initializedPlugin = await hre.wrapper.deploy(
+  const initializedPlugin: TokenVoting = await hre.wrapper.deploy(
     ARTIFACT_SOURCES.TokenVoting,
     {
       withProxy: true,
@@ -306,7 +305,7 @@ describe('TokenVoting', function () {
 
       // Try to reinitialize the initialized plugin.
       await expect(
-        initializedPlugin[INITIALIZE_SIGNATURE](
+        initializedPlugin.initialize(
           dao.address,
           defaultVotingSettings,
           token.address,
@@ -330,7 +329,7 @@ describe('TokenVoting', function () {
 
       // Initialize the uninitialized plugin.
       await expect(
-        await uninitializedPlugin[INITIALIZE_SIGNATURE](
+        await uninitializedPlugin.initialize(
           dao.address,
           defaultVotingSettings,
           token.address,
@@ -373,7 +372,7 @@ describe('TokenVoting', function () {
       const minApproval = pctToRatio(30);
 
       // Initialize the plugin.
-      await plugin[INITIALIZE_SIGNATURE](
+      await plugin.initialize(
         dao.address,
         votingSettings,
         token.address,
@@ -1070,8 +1069,9 @@ describe('TokenVoting', function () {
           },
           {
             receiver: bob.address,
-            amount:
-              voteSettingsWithMinProposerVotingPower.minProposerVotingPower,
+            amount: BigNumber.from(
+              await voteSettingsWithMinProposerVotingPower.minProposerVotingPower
+            ),
           },
         ]);
 

--- a/packages/contracts/test/10_unit-testing/11_plugin.ts
+++ b/packages/contracts/test/10_unit-testing/11_plugin.ts
@@ -879,7 +879,7 @@ describe('TokenVoting', function () {
 
           // Check that the snapshot block stored in the proposal struct is as expected.
           const proposal = await plugin.getProposal(id);
-          expect(proposal.parameters.snapshotBlock).to.equal(
+          expect(proposal.parameters.snapshotTimepoint).to.equal(
             expectedSnapshotBlockNumber
           );
 
@@ -1481,12 +1481,12 @@ describe('TokenVoting', function () {
       );
 
       expect(proposal.parameters.minVotingPower).to.equal(
-        (await plugin.totalVotingPower(proposal.parameters.snapshotBlock))
+        (await plugin.totalVotingPower(proposal.parameters.snapshotTimepoint))
           .mul(await defaultVotingSettings.minParticipation)
           .div(pctToRatio(100))
       );
 
-      expect(proposal.parameters.snapshotBlock).to.equal(
+      expect(proposal.parameters.snapshotTimepoint).to.equal(
         expectedSnapshotBlockNumber
       );
       expect(
@@ -1496,7 +1496,7 @@ describe('TokenVoting', function () {
       ).to.equal(proposal.parameters.endDate);
 
       expect(
-        await plugin.totalVotingPower(proposal.parameters.snapshotBlock)
+        await plugin.totalVotingPower(proposal.parameters.snapshotTimepoint)
       ).to.equal(10);
       expect(proposal.tally.yes).to.equal(0);
       expect(proposal.tally.no).to.equal(0);
@@ -1583,16 +1583,16 @@ describe('TokenVoting', function () {
         await defaultVotingSettings.supportThreshold
       );
       expect(proposal.parameters.minVotingPower).to.equal(
-        (await plugin.totalVotingPower(proposal.parameters.snapshotBlock))
+        (await plugin.totalVotingPower(proposal.parameters.snapshotTimepoint))
           .mul(await defaultVotingSettings.minParticipation)
           .div(pctToRatio(100))
       );
-      expect(proposal.parameters.snapshotBlock).to.equal(
+      expect(proposal.parameters.snapshotTimepoint).to.equal(
         expectedSnapshotBlockNumber
       );
 
       expect(
-        await plugin.totalVotingPower(proposal.parameters.snapshotBlock)
+        await plugin.totalVotingPower(proposal.parameters.snapshotTimepoint)
       ).to.equal(10);
       expect(proposal.tally.yes).to.equal(10);
       expect(proposal.tally.no).to.equal(0);
@@ -3822,7 +3822,7 @@ describe('TokenVoting', function () {
           const proposal = await plugin.getProposal(id);
           const tally = proposal.tally;
           const totalVotingPower = await plugin.totalVotingPower(
-            proposal.parameters.snapshotBlock
+            proposal.parameters.snapshotTimepoint
           );
           expect(
             totalVotingPower.sub(tally.yes).sub(tally.abstain) // this is the number of worst case no votes
@@ -3878,7 +3878,7 @@ describe('TokenVoting', function () {
           const proposal = await plugin.getProposal(id);
           const tally = proposal.tally;
           const totalVotingPower = await plugin.totalVotingPower(
-            proposal.parameters.snapshotBlock
+            proposal.parameters.snapshotTimepoint
           );
           expect(
             totalVotingPower.sub(tally.yes).sub(tally.no).sub(tally.abstain)
@@ -3983,7 +3983,7 @@ describe('TokenVoting', function () {
           const proposal = await plugin.getProposal(id);
           const tally = proposal.tally;
           const totalVotingPower = await plugin.totalVotingPower(
-            proposal.parameters.snapshotBlock
+            proposal.parameters.snapshotTimepoint
           );
           expect(
             totalVotingPower.sub(tally.yes).sub(tally.abstain) // this is the number of worst case no votes
@@ -4030,7 +4030,7 @@ describe('TokenVoting', function () {
           const proposal = await plugin.getProposal(id);
           const tally = proposal.tally;
           const totalVotingPower = await plugin.totalVotingPower(
-            proposal.parameters.snapshotBlock
+            proposal.parameters.snapshotTimepoint
           );
           expect(
             totalVotingPower.sub(tally.yes).sub(tally.no).sub(tally.abstain)
@@ -4096,9 +4096,11 @@ describe('TokenVoting', function () {
           );
 
           // Check that Alice and Bob's balances add up to the total voting power.
-          const snapshotBlock = (await plugin.getProposal(id)).parameters
-            .snapshotBlock;
-          const totalVotingPower = await plugin.totalVotingPower(snapshotBlock);
+          const snapshotTimepoint = (await plugin.getProposal(id)).parameters
+            .snapshotTimepoint;
+          const totalVotingPower = await plugin.totalVotingPower(
+            snapshotTimepoint
+          );
           expect(totalVotingPower).to.eq(balanceAlice.add(balanceBob));
 
           // Vote `Yes` with Alice.

--- a/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
+++ b/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
@@ -353,7 +353,7 @@ describe('TokenVotingSetup', function () {
 
       const data = await pluginSetup.encodeInstallationParameters(
         defaultVotingSettings,
-        // Instead of a token address, we pass Alice's address here.
+        // Instead of a token address, we pass DAO's address here.
         {addr: dao.address, name: 'x', symbol: 'y'},
         defaultMintSettings,
         defaultTargetConfig,
@@ -378,6 +378,7 @@ describe('TokenVotingSetup', function () {
         defaultMinApproval,
         defaultTargetConfig,
         defaultMetadata,
+        defaultExcludedAccounts,
       } = await loadFixtureCustom(fixture);
 
       const nonce = await hre.wrapper.getNonce(pluginSetup.address);
@@ -394,23 +395,18 @@ describe('TokenVotingSetup', function () {
         nonce + 2
       );
 
-      const data = abiCoder.encode(
-        getNamedTypesFromMetadata(
-          METADATA.build.pluginSetup.prepareInstallation.inputs
-        ),
-        [
-          Object.values(defaultVotingSettings),
-
-          [
-            erc20.address,
-            defaultTokenSettings.name,
-            defaultTokenSettings.symbol,
-          ],
-          Object.values(defaultMintSettings),
-          defaultTargetConfig,
-          defaultMinApproval,
-          defaultMetadata,
-        ]
+      const data = await pluginSetup.encodeInstallationParameters(
+        defaultVotingSettings,
+        {
+          addr: erc20.address,
+          name: defaultTokenSettings.name,
+          symbol: defaultTokenSettings.symbol,
+        },
+        defaultMintSettings,
+        defaultTargetConfig,
+        defaultMinApproval,
+        defaultMetadata,
+        defaultExcludedAccounts
       );
 
       const {
@@ -485,6 +481,7 @@ describe('TokenVotingSetup', function () {
         defaultTargetConfig,
         defaultMinApproval,
         defaultMetadata,
+        defaultExcludedAccounts,
       } = await loadFixtureCustom(fixture);
 
       const nonce = await hre.wrapper.getNonce(pluginSetup.address);
@@ -494,18 +491,18 @@ describe('TokenVotingSetup', function () {
         nonce
       );
 
-      const data = abiCoder.encode(
-        getNamedTypesFromMetadata(
-          METADATA.build.pluginSetup.prepareInstallation.inputs
-        ),
-        [
-          Object.values(defaultVotingSettings),
-          [erc20.address, 'myName', 'mySymb'],
-          Object.values(defaultMintSettings),
-          defaultTargetConfig,
-          defaultMinApproval,
-          defaultMetadata,
-        ]
+      const data = await pluginSetup.encodeInstallationParameters(
+        defaultVotingSettings,
+        {
+          addr: erc20.address,
+          name: 'myName',
+          symbol: 'mySymb',
+        },
+        defaultMintSettings,
+        defaultTargetConfig,
+        defaultMinApproval,
+        defaultMetadata,
+        defaultExcludedAccounts
       );
 
       await pluginSetup.prepareInstallation(dao.address, data);
@@ -564,11 +561,20 @@ describe('TokenVotingSetup', function () {
         defaultMinApproval,
         defaultTargetConfig,
         defaultMetadata,
+        defaultExcludedAccounts,
       } = await loadFixtureCustom(fixture);
 
       const governanceERC20 = await hre.wrapper.deploy(
         ARTIFACT_SOURCES.GovernanceERC20,
-        {args: [dao.address, 'name', 'symbol', {receivers: [], amounts: []}]}
+        {
+          args: [
+            dao.address,
+            'name',
+            'symbol',
+            {receivers: [], amounts: []},
+            [],
+          ],
+        }
       );
 
       const nonce = await hre.wrapper.getNonce(pluginSetup.address);
@@ -583,18 +589,18 @@ describe('TokenVotingSetup', function () {
         nonce + 1
       );
 
-      const data = abiCoder.encode(
-        getNamedTypesFromMetadata(
-          METADATA.build.pluginSetup.prepareInstallation.inputs
-        ),
-        [
-          Object.values(defaultVotingSettings),
-          [governanceERC20.address, '', ''],
-          Object.values(defaultMintSettings),
-          defaultTargetConfig,
-          defaultMinApproval,
-          defaultMetadata,
-        ]
+      const data = await pluginSetup.encodeInstallationParameters(
+        defaultVotingSettings,
+        {
+          addr: governanceERC20.address,
+          name: 'myName',
+          symbol: 'mySymb',
+        },
+        defaultMintSettings,
+        defaultTargetConfig,
+        defaultMinApproval,
+        defaultMetadata,
+        defaultExcludedAccounts
       );
 
       const {
@@ -1071,6 +1077,7 @@ describe('TokenVotingSetup', function () {
               receivers: [],
               amounts: [],
             },
+            [],
           ],
         }
       );
@@ -1082,6 +1089,7 @@ describe('TokenVotingSetup', function () {
             governanceERC20.address,
             defaultTokenSettings.name,
             defaultTokenSettings.symbol,
+            [],
           ],
         }
       );

--- a/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
+++ b/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
@@ -101,7 +101,7 @@ async function fixture(): Promise<FixtureResult> {
   const governanceERC20Base = await hre.wrapper.deploy(
     ARTIFACT_SOURCES.GovernanceERC20,
     {
-      args: [AddressZero, 'gov', 'GOV', defaultMintSettings],
+      args: [AddressZero, 'gov', 'GOV', defaultMintSettings, []],
     }
   );
 
@@ -109,7 +109,7 @@ async function fixture(): Promise<FixtureResult> {
   const governanceWrappedERC20Base = await hre.wrapper.deploy(
     ARTIFACT_SOURCES.GovernanceWrappedERC20,
     {
-      args: [AddressZero, 'wrappedGov', 'wGOV'],
+      args: [AddressZero, 'wrappedGov', 'wGOV', []],
     }
   );
 

--- a/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
+++ b/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
@@ -67,6 +67,7 @@ type FixtureResult = {
   defaultMintSettings: GovernanceERC20.MintSettingsStruct;
   defaultMinApproval: BigNumber;
   defaultMetadata: string;
+  defaultExcludedAccounts: string[];
   updateMinApproval: BigNumber;
   updateMetadata: string;
   updateTargetConfig: TargetConfig;
@@ -130,6 +131,7 @@ async function fixture(): Promise<FixtureResult> {
     target: dao.address,
     operation: Op.call,
   };
+  const defaultExcludedAccounts: string[] = [];
 
   const defaultMetadata: string = '0x11';
 
@@ -143,20 +145,31 @@ async function fixture(): Promise<FixtureResult> {
 
   const defaultMinApproval = pctToRatio(30);
 
-  // Provide installation inputs
-  const prepareInstallationInputs = ethers.utils.defaultAbiCoder.encode(
-    getNamedTypesFromMetadata(
-      METADATA.build.pluginSetup.prepareInstallation.inputs
-    ),
-    [
-      Object.values(defaultVotingSettings),
-      Object.values(defaultTokenSettings),
-      Object.values(defaultMintSettings),
-      Object.values(defaultTargetConfig),
+  // // Provide installation inputs
+  // const prepareInstallationInputs = ethers.utils.defaultAbiCoder.encode(
+  //   getNamedTypesFromMetadata(
+  //     METADATA.build.pluginSetup.prepareInstallation.inputs
+  //   ),
+  //   [
+  //     Object.values(defaultVotingSettings),
+  //     Object.values(defaultTokenSettings),
+  //     Object.values(defaultMintSettings),
+  //     Object.values(defaultTargetConfig),
+  //     defaultMinApproval,
+  //     defaultMetadata,
+  //   ]
+  // );
+
+  const prepareInstallationInputs =
+    await pluginSetup.encodeInstallationParameters(
+      defaultVotingSettings,
+      defaultTokenSettings,
+      defaultMintSettings,
+      defaultTargetConfig,
       defaultMinApproval,
       defaultMetadata,
-    ]
-  );
+      defaultExcludedAccounts
+    );
 
   // Provide uninstallation inputs
   const prepareUninstallationInputs = ethers.utils.defaultAbiCoder.encode(
@@ -193,6 +206,7 @@ async function fixture(): Promise<FixtureResult> {
     defaultMinApproval,
     defaultMetadata,
     defaultTargetConfig,
+    defaultExcludedAccounts,
     updateMinApproval,
     updateTargetConfig,
     updateMetadata,
@@ -306,20 +320,18 @@ describe('TokenVotingSetup', function () {
         defaultMinApproval,
         defaultTargetConfig,
         defaultMetadata,
+        defaultExcludedAccounts,
       } = await loadFixtureCustom(fixture);
 
-      const data = abiCoder.encode(
-        getNamedTypesFromMetadata(
-          METADATA.build.pluginSetup.prepareInstallation.inputs
-        ),
-        [
-          Object.values(defaultVotingSettings),
-          [alice.address, '', ''], // Instead of a token address, we pass Alice's address here.
-          Object.values(defaultMintSettings),
-          defaultTargetConfig,
-          defaultMinApproval,
-          defaultMetadata,
-        ]
+      const data = await pluginSetup.encodeInstallationParameters(
+        defaultVotingSettings,
+        // Instead of a token address, we pass Alice's address here.
+        {addr: alice.address, name: 'x', symbol: 'y'},
+        defaultMintSettings,
+        defaultTargetConfig,
+        defaultMinApproval,
+        defaultMetadata,
+        defaultExcludedAccounts
       );
 
       await expect(pluginSetup.prepareInstallation(dao.address, data))
@@ -336,20 +348,18 @@ describe('TokenVotingSetup', function () {
         defaultMinApproval,
         defaultTargetConfig,
         defaultMetadata,
+        defaultExcludedAccounts,
       } = await loadFixtureCustom(fixture);
 
-      const data = abiCoder.encode(
-        getNamedTypesFromMetadata(
-          METADATA.build.pluginSetup.prepareInstallation.inputs
-        ),
-        [
-          Object.values(defaultVotingSettings),
-          [dao.address, '', ''],
-          Object.values(defaultMintSettings),
-          defaultTargetConfig,
-          defaultMinApproval,
-          defaultMetadata,
-        ]
+      const data = await pluginSetup.encodeInstallationParameters(
+        defaultVotingSettings,
+        // Instead of a token address, we pass Alice's address here.
+        {addr: dao.address, name: 'x', symbol: 'y'},
+        defaultMintSettings,
+        defaultTargetConfig,
+        defaultMinApproval,
+        defaultMetadata,
+        defaultExcludedAccounts
       );
 
       await expect(pluginSetup.prepareInstallation(dao.address, data))

--- a/packages/contracts/test/10_unit-testing/token/11_governance-erc20.ts
+++ b/packages/contracts/test/10_unit-testing/token/11_governance-erc20.ts
@@ -37,7 +37,8 @@ describe('GovernanceERC20', function () {
     string,
     string,
     string,
-    GovernanceERC20.MintSettingsStruct
+    GovernanceERC20.MintSettingsStruct,
+    string[]
   ];
 
   before(async () => {
@@ -59,6 +60,7 @@ describe('GovernanceERC20', function () {
       governanceERC20Name,
       governanceERC20Symbol,
       mintSettings,
+      [],
     ];
 
     token = await hre.wrapper.deploy(ARTIFACT_SOURCES.GovernanceERC20, {

--- a/packages/contracts/test/10_unit-testing/token/11_governance-erc20.ts
+++ b/packages/contracts/test/10_unit-testing/token/11_governance-erc20.ts
@@ -98,6 +98,7 @@ describe('GovernanceERC20', function () {
             governanceERC20Name,
             governanceERC20Symbol,
             {receivers: receivers, amounts: amounts},
+            [],
           ],
         })
       )
@@ -245,6 +246,7 @@ describe('GovernanceERC20', function () {
             receivers: [],
             amounts: [],
           },
+          [],
         ],
       });
 

--- a/packages/contracts/test/10_unit-testing/token/12_governance-wrapped-erc20.ts
+++ b/packages/contracts/test/10_unit-testing/token/12_governance-wrapped-erc20.ts
@@ -360,7 +360,7 @@ describe('GovernanceWrappedERC20', function () {
       token = await hre.wrapper.deploy(
         ARTIFACT_SOURCES.GovernanceWrappedERC20,
         {
-          args: [erc20.address, 'name', 'symbol'],
+          args: [erc20.address, 'name', 'symbol', []],
         }
       );
 

--- a/packages/contracts/test/10_unit-testing/token/12_governance-wrapped-erc20.ts
+++ b/packages/contracts/test/10_unit-testing/token/12_governance-wrapped-erc20.ts
@@ -43,7 +43,7 @@ describe('GovernanceWrappedERC20', function () {
   let defaultBalances: AccountBalance[];
 
   let defaultExistingERC20InitData: [string, string];
-  let defaultGovernanceWrappedERC20InitData: [string, string, string];
+  let defaultGovernanceWrappedERC20InitData: [string, string, string, string[]];
 
   before(async () => {
     signers = await ethers.getSigners();
@@ -77,6 +77,7 @@ describe('GovernanceWrappedERC20', function () {
       erc20.address,
       governanceWrappedERC20Name,
       governanceWrappedERC20Symbol,
+      [],
     ];
 
     governanceToken = await hre.wrapper.deploy(

--- a/packages/contracts/test/20_integration-testing/22_setup-processing.ts
+++ b/packages/contracts/test/20_integration-testing/22_setup-processing.ts
@@ -43,9 +43,9 @@ import {BigNumber} from '@ethersproject/bignumber';
 import {loadFixture} from '@nomicfoundation/hardhat-network-helpers';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
 import {expect} from 'chai';
-import env, {deployments, ethers} from 'hardhat';
+import hre, {deployments, ethers} from 'hardhat';
 
-const productionNetworkName = getProductionNetworkName(env);
+const productionNetworkName = getProductionNetworkName(hre);
 
 type FixtureResult = {
   deployer: SignerWithAddress;
@@ -65,6 +65,7 @@ type FixtureResult = {
   defaultMintSettings: GovernanceERC20.MintSettingsStruct;
   defaultMinApproval: BigNumber;
   defaultMetadata: string;
+  defaultExcludedAccounts: string[];
   defaultTargetConfig: TargetConfig;
   prepareInstallationInputs: string;
   prepareInstallData: any;
@@ -107,7 +108,7 @@ async function fixture(): Promise<FixtureResult> {
   );
 
   // Get the deployed `PluginRepo`
-  const {pluginRepo, ensDomain} = await findPluginRepo(env);
+  const {pluginRepo, ensDomain} = await findPluginRepo(hre);
   if (pluginRepo === null) {
     throw `PluginRepo '${ensDomain}' does not exist yet.`;
   }
@@ -155,6 +156,7 @@ async function fixture(): Promise<FixtureResult> {
   };
 
   const defaultMetadata: string = '0x11';
+  const defaultExcludedAccounts: string[] = [];
 
   // Provide uninstallation inputs
   const prepareInstallationInputs = ethers.utils.defaultAbiCoder.encode(
@@ -168,6 +170,7 @@ async function fixture(): Promise<FixtureResult> {
       Object.values(defaultTargetConfig),
       defaultMinApproval,
       defaultMetadata,
+      defaultExcludedAccounts,
     ]
   );
 
@@ -178,6 +181,7 @@ async function fixture(): Promise<FixtureResult> {
     targetConfig: Object.values(defaultTargetConfig),
     defaultMinApproval,
     defaultMetadata,
+    defaultExcludedAccounts,
   };
 
   const prepareUpdateData = [
@@ -201,6 +205,7 @@ async function fixture(): Promise<FixtureResult> {
     defaultMintSettings,
     defaultMinApproval,
     defaultMetadata,
+    defaultExcludedAccounts,
     defaultTargetConfig,
     prepareInstallationInputs,
     prepareInstallData,
@@ -289,6 +294,7 @@ skipTestSuiteIfNetworkIsZkSync(
         pluginSetupRefLatestBuild,
         defaultMinApproval,
         defaultMetadata,
+        defaultExcludedAccounts,
         defaultTargetConfig,
       } = await loadFixture(fixture);
 
@@ -318,6 +324,7 @@ skipTestSuiteIfNetworkIsZkSync(
         defaultTargetConfig,
         defaultMinApproval,
         defaultMetadata,
+        defaultExcludedAccounts,
       };
 
       const prepareInstallInputType = getNamedTypesFromMetadata(

--- a/packages/contracts/test/20_integration-testing/22_setup-processing.ts
+++ b/packages/contracts/test/20_integration-testing/22_setup-processing.ts
@@ -102,7 +102,8 @@ async function fixture(): Promise<FixtureResult> {
     {
       receivers: [deployer.address],
       amounts: ['100'],
-    }
+    },
+    []
   );
 
   // Get the deployed `PluginRepo`

--- a/packages/contracts/test/20_integration-testing/22_setup-processing.ts
+++ b/packages/contracts/test/20_integration-testing/22_setup-processing.ts
@@ -1,5 +1,11 @@
 import {METADATA, VERSION} from '../../plugin-settings';
-import {GovernanceERC20, TokenVoting__factory} from '../../typechain';
+import {
+  GovernanceERC20,
+  PluginUpgradeableSetup__factory,
+  TokenVoting__factory,
+} from '../../typechain';
+import {PromiseOrValue} from '../../typechain/common';
+import {PluginUUPSUpgradeable__factory} from '../../typechain/factories/@aragon/osx-v1.3.0/core/plugin';
 import {MajorityVotingBase} from '../../typechain/src/MajorityVotingBase';
 import {getProductionNetworkName, findPluginRepo} from '../../utils/helpers';
 import {skipTestSuiteIfNetworkIsZkSync} from '../test-utils/skip-functions';
@@ -7,6 +13,7 @@ import {
   Operation,
   TargetConfig,
   latestInitializerVersion,
+  latestPluginBuild,
 } from '../test-utils/token-voting-constants';
 import {
   GovernanceERC20__factory,
@@ -19,6 +26,7 @@ import {
   installPLugin,
   uninstallPLugin,
   updateFromBuildTest,
+  updatePlugin,
 } from './test-helpers';
 import {
   getLatestNetworkDeployment,
@@ -27,6 +35,7 @@ import {
 import {
   DAO_PERMISSIONS,
   PLUGIN_SETUP_PROCESSOR_PERMISSIONS,
+  PLUGIN_UUPS_UPGRADEABLE_PERMISSIONS,
   TIME,
   UnsupportedNetworkError,
   getNamedTypesFromMetadata,
@@ -39,11 +48,13 @@ import {
   PluginSetupProcessor__factory,
   DAO,
 } from '@aragon/osx-ethers';
-import {BigNumber} from '@ethersproject/bignumber';
+import {BigNumber, BigNumberish} from '@ethersproject/bignumber';
 import {loadFixture} from '@nomicfoundation/hardhat-network-helpers';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
 import {expect} from 'chai';
 import hre, {deployments, ethers} from 'hardhat';
+
+const OZ_INITIALIZED_SLOT_POSITION = 0;
 
 const productionNetworkName = getProductionNetworkName(hre);
 
@@ -68,8 +79,24 @@ type FixtureResult = {
   defaultExcludedAccounts: string[];
   defaultTargetConfig: TargetConfig;
   prepareInstallationInputs: string;
-  prepareInstallData: any;
-  prepareUpdateData: any;
+  prepareInstallData: {
+    votingSettings: PromiseOrValue<BigNumberish>[];
+    tokenSettings: string[];
+    mintSettings: never[][];
+    targetConfig: (string | Operation)[];
+    defaultMinApproval: BigNumber;
+    defaultMetadata: string;
+    defaultExcludedAccounts: string[];
+  };
+  prepareUpdateData: readonly [
+    BigNumber,
+    {
+      target: string;
+      operation: Operation;
+    },
+    string,
+    string[]
+  ];
 };
 
 async function fixture(): Promise<FixtureResult> {
@@ -188,7 +215,9 @@ async function fixture(): Promise<FixtureResult> {
     defaultMinApproval,
     defaultTargetConfig,
     defaultMetadata,
-  ];
+    defaultExcludedAccounts,
+  ] as const;
+
   // Provide update inputs
   // const prepareUpdateBuild3Data = [defaultMinApproval];
   return {

--- a/packages/contracts/test/30_regression-testing/31_upgradeability.ts
+++ b/packages/contracts/test/30_regression-testing/31_upgradeability.ts
@@ -304,6 +304,7 @@ async function fixture(): Promise<FixtureResult> {
         receivers: [],
         amounts: [],
       },
+      [],
     ],
   });
 

--- a/packages/contracts/test/30_regression-testing/31_upgradeability.ts
+++ b/packages/contracts/test/30_regression-testing/31_upgradeability.ts
@@ -7,7 +7,6 @@ import {MajorityVotingBase} from '../../typechain/src';
 import {ZK_SYNC_NETWORKS} from '../../utils/zkSync';
 import {loadFixtureCustom} from '../test-utils/fixture';
 import {
-  INITIALIZE_SIGNATURE,
   latestInitializerVersion,
   Operation,
   TargetConfig,

--- a/packages/contracts/test/30_regression-testing/31_upgradeability.ts
+++ b/packages/contracts/test/30_regression-testing/31_upgradeability.ts
@@ -12,8 +12,8 @@ import {
   TargetConfig,
 } from '../test-utils/token-voting-constants';
 import {
-  TokenVoting_V1_0_0__factory,
-  TokenVoting_V1_3_0__factory,
+  TokenVoting_r1_b1__factory,
+  TokenVoting_r1_b2__factory,
   TokenVoting__factory,
 } from '../test-utils/typechain-versions';
 import {
@@ -69,7 +69,7 @@ describe('Upgrades', () => {
     const {deployer, dao, defaultInitData, encodeDataForUpgrade} =
       await loadFixtureCustom(fixture);
     const currentContractFactory = new TokenVoting__factory(deployer);
-    const legacyContractFactory = new TokenVoting_V1_0_0__factory(deployer);
+    const legacyContractFactory = new TokenVoting_r1_b1__factory(deployer);
 
     const data = [
       0,
@@ -91,7 +91,7 @@ describe('Upgrades', () => {
           defaultInitData.metadata,
         ],
       },
-      ARTIFACT_SOURCES.TokenVoting_V1_0_0,
+      ARTIFACT_SOURCES.TokenVoting_r1_b1,
       ARTIFACT_SOURCES.TokenVoting,
       PLUGIN_UUPS_UPGRADEABLE_PERMISSIONS.UPGRADE_PLUGIN_PERMISSION_ID,
       dao,
@@ -172,7 +172,7 @@ describe('Upgrades', () => {
     const {deployer, dao, defaultInitData, encodeDataForUpgrade} =
       await loadFixtureCustom(fixture);
     const currentContractFactory = new TokenVoting__factory(deployer);
-    const legacyContractFactory = new TokenVoting_V1_3_0__factory(deployer);
+    const legacyContractFactory = new TokenVoting_r1_b2__factory(deployer);
 
     const data = [
       0,
@@ -194,7 +194,7 @@ describe('Upgrades', () => {
           defaultInitData.metadata,
         ],
       },
-      ARTIFACT_SOURCES.TokenVoting_V1_3_0,
+      ARTIFACT_SOURCES.TokenVoting_r1_b2,
       ARTIFACT_SOURCES.TokenVoting,
       PLUGIN_UUPS_UPGRADEABLE_PERMISSIONS.UPGRADE_PLUGIN_PERMISSION_ID,
       dao,

--- a/packages/contracts/test/test-utils/token-voting-constants.ts
+++ b/packages/contracts/test/test-utils/token-voting-constants.ts
@@ -60,5 +60,5 @@ export type TargetConfig = {
   operation: number;
 };
 
-export const latestInitializerVersion = 2;
+export const latestInitializerVersion = 3;
 export const latestPluginBuild = VERSION.build;

--- a/packages/contracts/test/test-utils/token-voting-constants.ts
+++ b/packages/contracts/test/test-utils/token-voting-constants.ts
@@ -44,9 +44,6 @@ export const VOTING_EVENTS = {
 
 export const ANY_ADDR = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF';
 
-export const INITIALIZE_SIGNATURE =
-  'initialize(address,(uint8,uint32,uint32,uint64,uint256),address,(address,uint8),uint256,bytes)';
-
 export const CREATE_PROPOSAL_SIGNATURE =
   'createProposal(bytes,(address,uint256,bytes)[],uint256,uint64,uint64,uint8,bool)';
 

--- a/packages/contracts/test/test-utils/typechain-versions.ts
+++ b/packages/contracts/test/test-utils/typechain-versions.ts
@@ -3,8 +3,9 @@
 /// Import as needed in the test files, and use the correct version of the contract.
 
 /* TokenVoting */
-export {TokenVoting__factory as TokenVoting_V1_0_0__factory} from '../../typechain/factories/@aragon/osx-v1.0.0/plugins/governance/majority-voting/token/TokenVoting__factory';
-export {TokenVoting__factory as TokenVoting_V1_3_0__factory} from '../../typechain/factories/@aragon/osx-v1.3.0/plugins/governance/majority-voting/token/TokenVoting__factory';
+export {TokenVoting__factory as TokenVoting_r1_b1__factory} from '../../typechain/factories/@aragon/osx-v1.0.0/plugins/governance/majority-voting/token/TokenVoting__factory';
+export {TokenVoting__factory as TokenVoting_r1_b2__factory} from '../../typechain/factories/@aragon/osx-v1.3.0/plugins/governance/majority-voting/token/TokenVoting__factory';
+export {TokenVoting__factory as TokenVoting_r1_b3__factory} from '../../typechain/factories/@aragon/token-voting-plugin-r1-b3/src/TokenVoting__factory';
 export {TokenVoting__factory} from '../../typechain/factories/src/TokenVoting__factory';
 export {TokenVoting} from '../../typechain/src/TokenVoting';
 
@@ -13,14 +14,16 @@ export {TokenVotingSetup__factory} from '../../typechain';
 export {TokenVotingSetup} from '../../typechain';
 
 /* Governance ERC20 */
-export {GovernanceERC20__factory as GovernanceERC20_V1_0_0__factory} from '../../typechain/factories/@aragon/osx-v1.0.0/token/ERC20/governance/GovernanceERC20__factory';
-export {GovernanceERC20__factory as GovernanceERC20_V1_3_0__factory} from '../../typechain/factories/@aragon/osx-v1.3.0/token/ERC20/governance/GovernanceERC20__factory';
+export {GovernanceERC20__factory as GovernanceERC20_r1_b1__factory} from '../../typechain/factories/@aragon/osx-v1.0.0/token/ERC20/governance/GovernanceERC20__factory';
+export {GovernanceERC20__factory as GovernanceERC20_r1_b2__factory} from '../../typechain/factories/@aragon/osx-v1.3.0/token/ERC20/governance/GovernanceERC20__factory';
+export {GovernanceERC20__factory as GovernanceERC20_r1_b3__factory} from '../../typechain/factories/@aragon/token-voting-plugin-r1-b3/src/ERC20/governance/GovernanceERC20__factory';
 export {GovernanceERC20__factory} from '../../typechain/factories/src/ERC20/governance/GovernanceERC20__factory';
 export {GovernanceERC20} from '../../typechain/src/ERC20/governance/GovernanceERC20';
 
 /* Governance Wrapped ERC20 */
-export {GovernanceWrappedERC20__factory as GovernanceWrappedERC20_V1_0_0__factory} from '../../typechain/factories/@aragon/osx-v1.0.0/token/ERC20/governance/GovernanceWrappedERC20__factory';
-export {GovernanceWrappedERC20__factory as GovernanceWrappedERC20_V1_3_0__factory} from '../../typechain/factories/@aragon/osx-v1.3.0/token/ERC20/governance/GovernanceWrappedERC20__factory';
+export {GovernanceWrappedERC20__factory as GovernanceWrappedERC20_r1_b1__factory} from '../../typechain/factories/@aragon/osx-v1.0.0/token/ERC20/governance/GovernanceWrappedERC20__factory';
+export {GovernanceWrappedERC20__factory as GovernanceWrappedERC20_r1_b2__factory} from '../../typechain/factories/@aragon/osx-v1.3.0/token/ERC20/governance/GovernanceWrappedERC20__factory';
+export {GovernanceWrappedERC20__factory as GovernanceWrappedERC20_r1_b3__factory} from '../../typechain/factories/@aragon/token-voting-plugin-r1-b3/src/ERC20/governance/GovernanceWrappedERC20__factory';
 export {GovernanceWrappedERC20__factory} from '../../typechain/factories/src/ERC20/governance/GovernanceWrappedERC20__factory';
 export {GovernanceWrappedERC20} from '../../typechain/src/ERC20/governance/GovernanceWrappedERC20';
 

--- a/packages/contracts/test/test-utils/wrapper/index.ts
+++ b/packages/contracts/test/test-utils/wrapper/index.ts
@@ -14,10 +14,12 @@ export const ARTIFACT_SOURCES = {
   MajorityVotingMock: 'src/mocks/MajorityVotingMock.sol:MajorityVotingMock',
   VotingPowerCondition: 'src/VotingPowerCondition.sol:VotingPowerCondition',
   TokenVoting: 'src/TokenVoting.sol:TokenVoting',
-  TokenVoting_V1_0_0:
+  TokenVoting_r1_b1:
     '@aragon/osx-v1.0.0/plugins/governance/majority-voting/token/TokenVoting.sol:TokenVoting',
-  TokenVoting_V1_3_0:
+  TokenVoting_r1_b2:
     '@aragon/osx-v1.3.0/plugins/governance/majority-voting/token/TokenVoting.sol:TokenVoting',
+  TokenVoting_r1_b3:
+    '@aragon/token-voting-plugin-r1-b3/src/TokenVoting.sol:TokenVoting',
   TestGovernanceERC20: 'src/mocks/TestGovernanceERC20.sol:TestGovernanceERC20',
   GovernanceERC20: 'src/ERC20/governance/GovernanceERC20.sol:GovernanceERC20',
   ERC20Mock: 'src/mocks/ERC20Mock.sol:ERC20Mock',

--- a/packages/contracts/types/hardhat.ts
+++ b/packages/contracts/types/hardhat.ts
@@ -1,5 +1,3 @@
-
-
 import {Wrapper} from '../test/test-utils/wrapper';
 
 export type VerifyEntry = {
@@ -13,4 +11,3 @@ declare module 'hardhat/types/runtime' {
     aragonToVerifyContracts: VerifyEntry[];
   }
 }
-

--- a/packages/contracts/yarn.lock
+++ b/packages/contracts/yarn.lock
@@ -254,6 +254,21 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
+"@ethersproject/abi@5.8.0", "@ethersproject/abi@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.8.0.tgz#e79bb51940ac35fe6f3262d7fe2cdb25ad5f07d9"
+  integrity sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==
+  dependencies:
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/hash" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
+
 "@ethersproject/abstract-provider@5.7.0", "@ethersproject/abstract-provider@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz#b0a8550f88b6bf9d51f90e4795d48294630cb9ef"
@@ -267,6 +282,19 @@
     "@ethersproject/transactions" "^5.7.0"
     "@ethersproject/web" "^5.7.0"
 
+"@ethersproject/abstract-provider@5.8.0", "@ethersproject/abstract-provider@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz#7581f9be601afa1d02b95d26b9d9840926a35b0c"
+  integrity sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/networks" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/transactions" "^5.8.0"
+    "@ethersproject/web" "^5.8.0"
+
 "@ethersproject/abstract-signer@5.7.0", "@ethersproject/abstract-signer@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz#13f4f32117868452191a4649723cb086d2b596b2"
@@ -277,6 +305,17 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
+
+"@ethersproject/abstract-signer@5.8.0", "@ethersproject/abstract-signer@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz#8d7417e95e4094c1797a9762e6789c7356db0754"
+  integrity sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
 
 "@ethersproject/address@5.7.0", "@ethersproject/address@^5.0.2", "@ethersproject/address@^5.7.0":
   version "5.7.0"
@@ -289,12 +328,30 @@
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/rlp" "^5.7.0"
 
+"@ethersproject/address@5.8.0", "@ethersproject/address@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.8.0.tgz#3007a2c352eee566ad745dca1dbbebdb50a6a983"
+  integrity sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/rlp" "^5.8.0"
+
 "@ethersproject/base64@5.7.0", "@ethersproject/base64@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.7.0.tgz#ac4ee92aa36c1628173e221d0d01f53692059e1c"
   integrity sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
+
+"@ethersproject/base64@5.8.0", "@ethersproject/base64@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.8.0.tgz#61c669c648f6e6aad002c228465d52ac93ee83eb"
+  integrity sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
 
 "@ethersproject/basex@5.7.0", "@ethersproject/basex@^5.7.0":
   version "5.7.0"
@@ -303,6 +360,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
+
+"@ethersproject/basex@5.8.0", "@ethersproject/basex@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.8.0.tgz#1d279a90c4be84d1c1139114a1f844869e57d03a"
+  integrity sha512-PIgTszMlDRmNwW9nhS6iqtVfdTAKosA7llYXNmGPw4YAI1PUyMv28988wAb41/gHF/WqGdoLv0erHaRcHRKW2Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
 
 "@ethersproject/bignumber@5.7.0", "@ethersproject/bignumber@^5.7.0":
   version "5.7.0"
@@ -313,6 +378,15 @@
     "@ethersproject/logger" "^5.7.0"
     bn.js "^5.2.1"
 
+"@ethersproject/bignumber@5.8.0", "@ethersproject/bignumber@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.8.0.tgz#c381d178f9eeb370923d389284efa19f69efa5d7"
+  integrity sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    bn.js "^5.2.1"
+
 "@ethersproject/bytes@5.7.0", "@ethersproject/bytes@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.7.0.tgz#a00f6ea8d7e7534d6d87f47188af1148d71f155d"
@@ -320,12 +394,26 @@
   dependencies:
     "@ethersproject/logger" "^5.7.0"
 
+"@ethersproject/bytes@5.8.0", "@ethersproject/bytes@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.8.0.tgz#9074820e1cac7507a34372cadeb035461463be34"
+  integrity sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==
+  dependencies:
+    "@ethersproject/logger" "^5.8.0"
+
 "@ethersproject/constants@5.7.0", "@ethersproject/constants@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.7.0.tgz#df80a9705a7e08984161f09014ea012d1c75295e"
   integrity sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==
   dependencies:
     "@ethersproject/bignumber" "^5.7.0"
+
+"@ethersproject/constants@5.8.0", "@ethersproject/constants@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.8.0.tgz#12f31c2f4317b113a4c19de94e50933648c90704"
+  integrity sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.8.0"
 
 "@ethersproject/contracts@5.7.0", "@ethersproject/contracts@^5.7.0":
   version "5.7.0"
@@ -343,6 +431,22 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/transactions" "^5.7.0"
 
+"@ethersproject/contracts@5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.8.0.tgz#243a38a2e4aa3e757215ea64e276f8a8c9d8ed73"
+  integrity sha512-0eFjGz9GtuAi6MZwhb4uvUM216F38xiuR0yYCjKJpNfSEy4HUM8hvqqBj9Jmm0IUz8l0xKEhWwLIhPgxNY0yvQ==
+  dependencies:
+    "@ethersproject/abi" "^5.8.0"
+    "@ethersproject/abstract-provider" "^5.8.0"
+    "@ethersproject/abstract-signer" "^5.8.0"
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/transactions" "^5.8.0"
+
 "@ethersproject/hash@5.7.0", "@ethersproject/hash@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.7.0.tgz#eb7aca84a588508369562e16e514b539ba5240a7"
@@ -357,6 +461,21 @@
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/hash@5.8.0", "@ethersproject/hash@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.8.0.tgz#b8893d4629b7f8462a90102572f8cd65a0192b4c"
+  integrity sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.8.0"
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/base64" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
 
 "@ethersproject/hdnode@5.7.0", "@ethersproject/hdnode@^5.7.0":
   version "5.7.0"
@@ -375,6 +494,24 @@
     "@ethersproject/strings" "^5.7.0"
     "@ethersproject/transactions" "^5.7.0"
     "@ethersproject/wordlists" "^5.7.0"
+
+"@ethersproject/hdnode@5.8.0", "@ethersproject/hdnode@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.8.0.tgz#a51ae2a50bcd48ef6fd108c64cbae5e6ff34a761"
+  integrity sha512-4bK1VF6E83/3/Im0ERnnUeWOY3P1BZml4ZD3wcH8Ys0/d1h1xaFt6Zc+Dh9zXf9TapGro0T4wvO71UTCp3/uoA==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.8.0"
+    "@ethersproject/basex" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/pbkdf2" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/sha2" "^5.8.0"
+    "@ethersproject/signing-key" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
+    "@ethersproject/transactions" "^5.8.0"
+    "@ethersproject/wordlists" "^5.8.0"
 
 "@ethersproject/json-wallets@5.7.0", "@ethersproject/json-wallets@^5.7.0":
   version "5.7.0"
@@ -395,6 +532,25 @@
     aes-js "3.0.0"
     scrypt-js "3.0.1"
 
+"@ethersproject/json-wallets@5.8.0", "@ethersproject/json-wallets@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.8.0.tgz#d18de0a4cf0f185f232eb3c17d5e0744d97eb8c9"
+  integrity sha512-HxblNck8FVUtNxS3VTEYJAcwiKYsBIF77W15HufqlBF9gGfhmYOJtYZp8fSDZtn9y5EaXTE87zDwzxRoTFk11w==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.8.0"
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/hdnode" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/pbkdf2" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/random" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
+    "@ethersproject/transactions" "^5.8.0"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
+
 "@ethersproject/keccak256@5.7.0", "@ethersproject/keccak256@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.7.0.tgz#3186350c6e1cd6aba7940384ec7d6d9db01f335a"
@@ -403,10 +559,23 @@
     "@ethersproject/bytes" "^5.7.0"
     js-sha3 "0.8.0"
 
+"@ethersproject/keccak256@5.8.0", "@ethersproject/keccak256@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.8.0.tgz#d2123a379567faf2d75d2aaea074ffd4df349e6a"
+  integrity sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    js-sha3 "0.8.0"
+
 "@ethersproject/logger@5.7.0", "@ethersproject/logger@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
   integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
+
+"@ethersproject/logger@5.8.0", "@ethersproject/logger@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.8.0.tgz#f0232968a4f87d29623a0481690a2732662713d6"
+  integrity sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==
 
 "@ethersproject/networks@5.7.1", "@ethersproject/networks@^5.7.0":
   version "5.7.1"
@@ -414,6 +583,13 @@
   integrity sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==
   dependencies:
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/networks@5.8.0", "@ethersproject/networks@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.8.0.tgz#8b4517a3139380cba9fb00b63ffad0a979671fde"
+  integrity sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==
+  dependencies:
+    "@ethersproject/logger" "^5.8.0"
 
 "@ethersproject/pbkdf2@5.7.0", "@ethersproject/pbkdf2@^5.7.0":
   version "5.7.0"
@@ -423,12 +599,27 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/sha2" "^5.7.0"
 
+"@ethersproject/pbkdf2@5.8.0", "@ethersproject/pbkdf2@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.8.0.tgz#cd2621130e5dd51f6a0172e63a6e4a0c0a0ec37e"
+  integrity sha512-wuHiv97BrzCmfEaPbUFpMjlVg/IDkZThp9Ri88BpjRleg4iePJaj2SW8AIyE8cXn5V1tuAaMj6lzvsGJkGWskg==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/sha2" "^5.8.0"
+
 "@ethersproject/properties@5.7.0", "@ethersproject/properties@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.7.0.tgz#a6e12cb0439b878aaf470f1902a176033067ed30"
   integrity sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==
   dependencies:
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/properties@5.8.0", "@ethersproject/properties@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.8.0.tgz#405a8affb6311a49a91dabd96aeeae24f477020e"
+  integrity sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==
+  dependencies:
+    "@ethersproject/logger" "^5.8.0"
 
 "@ethersproject/providers@5.7.2", "@ethersproject/providers@^5.7.2":
   version "5.7.2"
@@ -456,6 +647,32 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
+"@ethersproject/providers@5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.8.0.tgz#6c2ae354f7f96ee150439f7de06236928bc04cb4"
+  integrity sha512-3Il3oTzEx3o6kzcg9ZzbE+oCZYyY+3Zh83sKkn4s1DZfTUjIegHnN2Cm0kbn9YFy45FDVcuCLLONhU7ny0SsCw==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.8.0"
+    "@ethersproject/abstract-signer" "^5.8.0"
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/base64" "^5.8.0"
+    "@ethersproject/basex" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/hash" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/networks" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/random" "^5.8.0"
+    "@ethersproject/rlp" "^5.8.0"
+    "@ethersproject/sha2" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
+    "@ethersproject/transactions" "^5.8.0"
+    "@ethersproject/web" "^5.8.0"
+    bech32 "1.1.4"
+    ws "8.18.0"
+
 "@ethersproject/random@5.7.0", "@ethersproject/random@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.7.0.tgz#af19dcbc2484aae078bb03656ec05df66253280c"
@@ -463,6 +680,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/random@5.8.0", "@ethersproject/random@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.8.0.tgz#1bced04d49449f37c6437c701735a1a022f0057a"
+  integrity sha512-E4I5TDl7SVqyg4/kkA/qTfuLWAQGXmSOgYyO01So8hLfwgKvYK5snIlzxJMk72IFdG/7oh8yuSqY2KX7MMwg+A==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
 
 "@ethersproject/rlp@5.7.0", "@ethersproject/rlp@^5.7.0":
   version "5.7.0"
@@ -472,6 +697,14 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
 
+"@ethersproject/rlp@5.8.0", "@ethersproject/rlp@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.8.0.tgz#5a0d49f61bc53e051532a5179472779141451de5"
+  integrity sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+
 "@ethersproject/sha2@5.7.0", "@ethersproject/sha2@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.7.0.tgz#9a5f7a7824ef784f7f7680984e593a800480c9fb"
@@ -479,6 +712,15 @@
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
+    hash.js "1.1.7"
+
+"@ethersproject/sha2@5.8.0", "@ethersproject/sha2@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.8.0.tgz#8954a613bb78dac9b46829c0a95de561ef74e5e1"
+  integrity sha512-dDOUrXr9wF/YFltgTBYS0tKslPEKr6AekjqDW2dbn1L1xmjGR+9GiKu4ajxovnrDbwxAKdHjW8jNcwfz8PAz4A==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
     hash.js "1.1.7"
 
 "@ethersproject/signing-key@5.7.0", "@ethersproject/signing-key@^5.7.0":
@@ -493,6 +735,18 @@
     elliptic "6.5.4"
     hash.js "1.1.7"
 
+"@ethersproject/signing-key@5.8.0", "@ethersproject/signing-key@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.8.0.tgz#9797e02c717b68239c6349394ea85febf8893119"
+  integrity sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    bn.js "^5.2.1"
+    elliptic "6.6.1"
+    hash.js "1.1.7"
+
 "@ethersproject/solidity@5.7.0", "@ethersproject/solidity@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.7.0.tgz#5e9c911d8a2acce2a5ebb48a5e2e0af20b631cb8"
@@ -505,6 +759,18 @@
     "@ethersproject/sha2" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
+"@ethersproject/solidity@5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.8.0.tgz#429bb9fcf5521307a9448d7358c26b93695379b9"
+  integrity sha512-4CxFeCgmIWamOHwYN9d+QWGxye9qQLilpgTU0XhYs1OahkclF+ewO+3V1U0mvpiuQxm5EHHmv8f7ClVII8EHsA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/sha2" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
+
 "@ethersproject/strings@5.7.0", "@ethersproject/strings@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.7.0.tgz#54c9d2a7c57ae8f1205c88a9d3a56471e14d5ed2"
@@ -513,6 +779,15 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/constants" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/strings@5.8.0", "@ethersproject/strings@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.8.0.tgz#ad79fafbf0bd272d9765603215ac74fd7953908f"
+  integrity sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
 
 "@ethersproject/transactions@5.7.0", "@ethersproject/transactions@^5.6.2", "@ethersproject/transactions@^5.7.0":
   version "5.7.0"
@@ -529,6 +804,21 @@
     "@ethersproject/rlp" "^5.7.0"
     "@ethersproject/signing-key" "^5.7.0"
 
+"@ethersproject/transactions@5.8.0", "@ethersproject/transactions@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.8.0.tgz#1e518822403abc99def5a043d1c6f6fe0007e46b"
+  integrity sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==
+  dependencies:
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/rlp" "^5.8.0"
+    "@ethersproject/signing-key" "^5.8.0"
+
 "@ethersproject/units@5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.7.0.tgz#637b563d7e14f42deeee39245275d477aae1d8b1"
@@ -537,6 +827,15 @@
     "@ethersproject/bignumber" "^5.7.0"
     "@ethersproject/constants" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/units@5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.8.0.tgz#c12f34ba7c3a2de0e9fa0ed0ee32f3e46c5c2c6a"
+  integrity sha512-lxq0CAnc5kMGIiWW4Mr041VT8IhNM+Pn5T3haO74XZWFulk7wH1Gv64HqE96hT4a7iiNMdOCFEBgaxWuk8ETKQ==
+  dependencies:
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
 
 "@ethersproject/wallet@5.7.0", "@ethersproject/wallet@^5.7.0":
   version "5.7.0"
@@ -559,6 +858,27 @@
     "@ethersproject/transactions" "^5.7.0"
     "@ethersproject/wordlists" "^5.7.0"
 
+"@ethersproject/wallet@5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.8.0.tgz#49c300d10872e6986d953e8310dc33d440da8127"
+  integrity sha512-G+jnzmgg6UxurVKRKvw27h0kvG75YKXZKdlLYmAHeF32TGUzHkOFd7Zn6QHOTYRFWnfjtSSFjBowKo7vfrXzPA==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.8.0"
+    "@ethersproject/abstract-signer" "^5.8.0"
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/hash" "^5.8.0"
+    "@ethersproject/hdnode" "^5.8.0"
+    "@ethersproject/json-wallets" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/random" "^5.8.0"
+    "@ethersproject/signing-key" "^5.8.0"
+    "@ethersproject/transactions" "^5.8.0"
+    "@ethersproject/wordlists" "^5.8.0"
+
 "@ethersproject/web@5.7.1", "@ethersproject/web@^5.7.0":
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.7.1.tgz#de1f285b373149bee5928f4eb7bcb87ee5fbb4ae"
@@ -570,6 +890,17 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
+"@ethersproject/web@5.8.0", "@ethersproject/web@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.8.0.tgz#3e54badc0013b7a801463a7008a87988efce8a37"
+  integrity sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==
+  dependencies:
+    "@ethersproject/base64" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
+
 "@ethersproject/wordlists@5.7.0", "@ethersproject/wordlists@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.7.0.tgz#8fb2c07185d68c3e09eb3bfd6e779ba2774627f5"
@@ -580,6 +911,17 @@
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/wordlists@5.8.0", "@ethersproject/wordlists@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.8.0.tgz#7a5654ee8d1bb1f4dbe43f91d217356d650ad821"
+  integrity sha512-2df9bbXicZws2Sb5S6ET493uJ0Z84Fjr3pC4tu/qlnZERibZCeUVuqdtt+7Tv9xxhUxHoIekIA7avrKUWHrezg==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/hash" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
 
 "@fastify/busboy@^2.0.0":
   version "2.1.1"
@@ -2935,6 +3277,13 @@ debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.3.4:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.1.tgz#e5a8bc6cbc4c6cd3e64308b0693a3d4fa550189b"
+  integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
+  dependencies:
+    ms "^2.1.3"
+
 decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -3210,7 +3559,7 @@ elliptic@6.5.4:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-elliptic@^6.4.0, elliptic@^6.5.2, elliptic@^6.5.7:
+elliptic@6.6.1, elliptic@^6.4.0, elliptic@^6.5.2, elliptic@^6.5.7:
   version "6.6.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
   integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
@@ -3606,6 +3955,42 @@ ethers@^5.0.13, ethers@^5.6.2, ethers@^5.7.0, ethers@^5.7.2, ethers@~5.7.0, ethe
     "@ethersproject/wallet" "5.7.0"
     "@ethersproject/web" "5.7.1"
     "@ethersproject/wordlists" "5.7.0"
+
+ethers@^5.6.1:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.8.0.tgz#97858dc4d4c74afce83ea7562fe9493cedb4d377"
+  integrity sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==
+  dependencies:
+    "@ethersproject/abi" "5.8.0"
+    "@ethersproject/abstract-provider" "5.8.0"
+    "@ethersproject/abstract-signer" "5.8.0"
+    "@ethersproject/address" "5.8.0"
+    "@ethersproject/base64" "5.8.0"
+    "@ethersproject/basex" "5.8.0"
+    "@ethersproject/bignumber" "5.8.0"
+    "@ethersproject/bytes" "5.8.0"
+    "@ethersproject/constants" "5.8.0"
+    "@ethersproject/contracts" "5.8.0"
+    "@ethersproject/hash" "5.8.0"
+    "@ethersproject/hdnode" "5.8.0"
+    "@ethersproject/json-wallets" "5.8.0"
+    "@ethersproject/keccak256" "5.8.0"
+    "@ethersproject/logger" "5.8.0"
+    "@ethersproject/networks" "5.8.0"
+    "@ethersproject/pbkdf2" "5.8.0"
+    "@ethersproject/properties" "5.8.0"
+    "@ethersproject/providers" "5.8.0"
+    "@ethersproject/random" "5.8.0"
+    "@ethersproject/rlp" "5.8.0"
+    "@ethersproject/sha2" "5.8.0"
+    "@ethersproject/signing-key" "5.8.0"
+    "@ethersproject/solidity" "5.8.0"
+    "@ethersproject/strings" "5.8.0"
+    "@ethersproject/transactions" "5.8.0"
+    "@ethersproject/units" "5.8.0"
+    "@ethersproject/wallet" "5.8.0"
+    "@ethersproject/web" "5.8.0"
+    "@ethersproject/wordlists" "5.8.0"
 
 ethjs-unit@0.1.6:
   version "0.1.6"
@@ -4295,6 +4680,16 @@ hardhat-gas-reporter@^1.0.9:
     array-uniq "1.0.3"
     eth-gas-reporter "^0.2.25"
     sha1 "^1.1.1"
+
+hardhat-tracer@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/hardhat-tracer/-/hardhat-tracer-3.2.0.tgz#a589b5657b3eaad79d40ad9b732050aa6ceaa855"
+  integrity sha512-rCG2XKKegtK0D0Lm/Df+OkJh7qC0TcpK9rUrMt8QAJ+fMy3TujmLkemZuJ3eKz/i8ROIXuUIrhyPU2hFuN3VdA==
+  dependencies:
+    chalk "^4.1.2"
+    debug "^4.3.4"
+    ethers "^5.6.1"
+    semver "^7.6.2"
 
 hardhat@^2.14.0, hardhat@^2.22.15:
   version "2.22.18"
@@ -8381,6 +8776,11 @@ ws@7.4.6:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
+ws@8.18.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
 ws@^3.0.0:
   version "3.3.3"

--- a/packages/contracts/yarn.lock
+++ b/packages/contracts/yarn.lock
@@ -61,6 +61,14 @@
     "@openzeppelin/contracts" "4.9.6"
     "@openzeppelin/contracts-upgradeable" "4.9.6"
 
+"@aragon/token-voting-plugin-r1-b3@https://gitpkg.now.sh/aragon/token-voting-plugin/packages/contracts?commit=release-v1.3":
+  version "1.3.0"
+  resolved "https://gitpkg.now.sh/aragon/token-voting-plugin/packages/contracts?commit=release-v1.3#8fd57907efbae61585f0e412a2d8074adcfbe6fa"
+  dependencies:
+    "@aragon/osx-commons-contracts" "^1.4.0"
+    "@openzeppelin/contracts" "^4.9.6"
+    "@openzeppelin/contracts-upgradeable" "^4.9.6"
+
 "@aws-crypto/sha256-js@1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz#02acd1a1fda92896fc5a28ec7c6e164644ea32fc"
@@ -7053,7 +7061,8 @@ string-format@^2.0.0:
   resolved "https://registry.yarnpkg.com/string-format/-/string-format-2.0.0.tgz#f2df2e7097440d3b65de31b6d40d54c96eaffb9b"
   integrity sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7078,15 +7087,6 @@ string-width@^2.1.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -7116,7 +7116,8 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7136,13 +7137,6 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -8351,7 +8345,8 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -8367,15 +8362,6 @@ wrap-ansi@^2.0.0:
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
 
 wrap-ansi@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
This PR adds support for:
- Voting tokens indexed by timestamps
- Permanently disabling the minting function
- Excluding certain addresses from the voting calculations